### PR TITLE
Add sg.conf to force load 'sg' module at boot time

### DIFF
--- a/sg.conf
+++ b/sg.conf
@@ -1,0 +1,2 @@
+# Load sg module at boot time (see bsc#761109 and also bsc#1036463)
+sg


### PR DESCRIPTION
It's currently shipped by systemd but it's more appropriate to ship
this via a package maintained by the kernel team, see bsc#1036463.