### PR TITLE
Add file system blacklist file (fate#326832).

### DIFF
--- a/modprobe.conf/modprobe.conf.fs-blacklist
+++ b/modprobe.conf/modprobe.conf.fs-blacklist
@@ -1,0 +1,32 @@
+# These file systems are not used on most systems but the kernel
+# will still happily load the modules for them when presented with
+# a potentially malicious device like a USB stick.  Many of these
+# have not been maintained except for in-kernel API compatibility
+# in many years, have not been audited, and may have security vulnerabilities.
+#
+# The following list only specifies local file systems since those are the
+# only ones that will be detected automatically by mount(8).
+#
+# Enable at your own risk.
+#
+blacklist adfs
+blacklist affs
+blacklist bfs
+blacklist befs
+blacklist cramfs
+blacklist efs
+blacklist erofs
+blacklist exofs
+blacklist freevxfs
+blacklist f2fs
+blacklist hfs
+blacklist hpfs
+blacklist jffs2
+blacklist jfs
+blacklist minix
+blacklist nilfs2
+blacklist qnx4
+blacklist qnx6
+blacklist sysv
+blacklist ubifs
+blacklist ufs

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -184,6 +184,7 @@ fi
 %dir %{_sysconfdir}/modprobe.d
 %config %{_sysconfdir}/modprobe.d/00-system.conf
 %config(noreplace) %{_sysconfdir}/modprobe.d/10-unsupported-modules.conf
+%config(noreplace) %{_sysconfdir}/modprobe.d/50-blacklist.conf
 %config(noreplace) %{_sysconfdir}/modprobe.d/99-local.conf
 %dir %{_sysconfdir}/depmod.d
 %config %{_sysconfdir}/depmod.d/00-system.conf

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -74,6 +74,7 @@ install -pm644 "10-unsupported-modules.conf" \
 	"%{buildroot}%{_sysconfdir}/modprobe.d/"
 install -pm644 00-system.conf "%{buildroot}%{_sysconfdir}/modprobe.d/"
 install -pm644 modprobe.conf/modprobe.conf.blacklist "%{buildroot}%{_sysconfdir}/modprobe.d/50-blacklist.conf"
+install -pm644 modprobe.conf/modprobe.conf.fs-blacklist "%{buildroot}%{_sysconfdir}/modprobe.d/60-filesystem-blacklist.conf"
 install -pm644 modprobe.conf/modprobe.conf.local "%{buildroot}%{_sysconfdir}/modprobe.d/99-local.conf"
 install -d -m 755 "%{buildroot}%{_sysconfdir}/depmod.d"
 install -pm 644 "depmod-00-system.conf" \
@@ -185,6 +186,7 @@ fi
 %config %{_sysconfdir}/modprobe.d/00-system.conf
 %config(noreplace) %{_sysconfdir}/modprobe.d/10-unsupported-modules.conf
 %config(noreplace) %{_sysconfdir}/modprobe.d/50-blacklist.conf
+%config(noreplace) %{_sysconfdir}/modprobe.d/60-filesystem-blacklist.conf
 %config(noreplace) %{_sysconfdir}/modprobe.d/99-local.conf
 %dir %{_sysconfdir}/depmod.d
 %config %{_sysconfdir}/depmod.d/00-system.conf


### PR DESCRIPTION
As automated fuzzer testing grows in popularity, we've seen an uptick of security vulnerabilities that are in rarely used file systems. Normally this isn't an issue but the combination of user-mountable file systems and the automatic mounting of file systems on removable devices means that unprivileged users can cause the automatic loading of kernel modules to handle those operations. This feature blacklists uncommon file systems by default and allows the user to enable them if their use requires them.

