### PR TITLE
Load fbcon automatically when needed on s390x

### DIFF
--- a/modprobe.conf/modprobe.conf.s390
+++ b/modprobe.conf/modprobe.conf.s390
@@ -40,5 +40,11 @@ alias iucv9               netiucv
 
 alias block-major-35 xpram
 
+# The framebuffer console is built as a module on s390, because it is
+# useful only to a KVM guest. But then it should be loaded together
+# with the corresponding DRM driver.
+# SUSE INITRD: virtio_gpu REQUIRES fbcon
+softdep virtio_gpu post: fbcon
+
 # end of s390 part for modprobe.conf
 

--- a/modprobe.conf/modprobe.conf.s390
+++ b/modprobe.conf/modprobe.conf.s390
@@ -43,7 +43,7 @@ alias block-major-35 xpram
 # The framebuffer console is built as a module on s390, because it is
 # useful only to a KVM guest. But then it should be loaded together
 # with the corresponding DRM driver.
-# SUSE INITRD: virtio_gpu REQUIRES fbcon
+# SUSE INITRD: virtio_gpu REQUIRES fbcon fb font bitblit softcursor fbcon_rotate fbcon_cw fbcon_ccw fbcon_ud
 softdep virtio_gpu post: fbcon
 
 # end of s390 part for modprobe.conf


### PR DESCRIPTION
When gpio_virtio is loaded on s390x, also load the framebuffer console (which is not built-in on s390).