### PR TITLE
modprobe.conf: add dependency of papr_scm on libnvdimm

### DIFF
--- a/modprobe.conf/modprobe.conf.ppc64le
+++ b/modprobe.conf/modprobe.conf.ppc64le
@@ -3,5 +3,8 @@
 # catas recovery conflicts with eeh (bsc#456389)
 options ib_mthca catas_reset_disable=1
 
+# bsc#1142152 papr_scm requires libnvdimm
+# SUSE INITRD: papr_scm REQUIRES libnvdimm
+
 # end of ppc64le part for modprobe.conf
 


### PR DESCRIPTION
(bsc#1142152, ltc#176292, FATE#327775).

libnvdimm is not included in the initramfs automatically.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>