### PR TITLE
Replace use of rpmsort with custom luarpmsort

### DIFF
--- a/driver-check.sh
+++ b/driver-check.sh
@@ -301,7 +301,7 @@ check_rpm "$smt"
 mkdir -p "$tmp/rpms"
 found_kernel=false
 for rpm in $(rpm -qa --qf '%{n}-%{v}-%{r}\n' 'kernel-*' '*-kmp-*' | \
-		/usr/lib/rpm/rpmsort); do
+		"$(dirname "$0")/luarpmsort" | tac); do
 	case "$rpm" in
 	kernel-source-* | kernel-syms-* | kernel-*-debug* | kernel-*-man-* | \
 	kernel-*-devel-* | kernel-firmware-* | kernel-coverage-* | \

--- a/luarpmsort
+++ b/luarpmsort
@@ -1,0 +1,44 @@
+#!/bin/bash
+rpmsort() {
+	script='
+function parse(ver)
+	local epoch, version, release = 0, ver, 0
+	_, eend, e = ver:find("^(%d+):")
+	if eend then
+		ver = ver:sub(eend + 1)
+		version = ver
+		epoch = e
+	end
+	_, _, v, r = ver:find("(.+)%-(.+)$")
+	if v then
+		version = v
+		release = r
+	end
+	return epoch, version, release
+end
+
+function pkgvercmp(a, b)
+	local ae, av, ar = parse(a)
+	local be, bv, br = parse(b)
+
+	local ecmp = rpm.vercmp(ae, be)
+	if ecmp ~= 0 then return ecmp end
+
+	local vcmp = rpm.vercmp(av, bv)
+	if vcmp ~= 0 then return vcmp end
+
+	return rpm.vercmp(ar, br)
+end	
+
+vers = {}
+for line in io.stdin:lines() do
+	table.insert(vers, line)
+end
+table.sort(vers, function(a, b) return pkgvercmp(a, b) == -1 end)
+print(table.concat(vers, "\n"))
+'
+
+	rpm --eval "%{lua: ${script}}"
+}
+
+rpmsort

--- a/luarpmsort
+++ b/luarpmsort
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Note: Unlike the old rpmsort, newer versions are at the top!
 rpmsort() {
 	script='
 function parse(ver)
@@ -34,7 +35,7 @@ vers = {}
 for line in io.stdin:lines() do
 	table.insert(vers, line)
 end
-table.sort(vers, function(a, b) return pkgvercmp(a, b) == -1 end)
+table.sort(vers, function(a, b) return pkgvercmp(a, b) == 1 end)
 print(table.concat(vers, "\n"))
 '
 

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -111,6 +111,7 @@ install -pm 644 "depmod-00-system.conf" \
 
 # "/usr/lib/module-init-tools" name hardcoded in KMPs, mkinitrd, etc.
 install -d -m 755 "%{buildroot}/usr/lib/module-init-tools"
+install -pm 755 luarpmsort "%{buildroot}/usr/lib/module-init-tools/"
 install -pm 755 weak-modules{,2} "%{buildroot}/usr/lib/module-init-tools/"
 install -pm 755 driver-check.sh "%{buildroot}/usr/lib/module-init-tools/"
 

--- a/weak-modules
+++ b/weak-modules
@@ -224,7 +224,7 @@ if [ -n "$add_modules" ]; then
 		    weak_krel=$(krel_of_module "$weak_module")
 		    if [ "$weak_krel" != "$module_krel" ] &&
 		       [ "$(printf "%s\n" "$weak_krel" "$module_krel" \
-			    | /usr/lib/rpm/rpmsort | head -n 1)" = \
+			    | "$(dirname "$0")/luarpmsort" | head -n 1)" = \
 			 "$module_krel" ]; then
 			# Keep modules from more recent kernels.
 			[ -n "$verbose" ] && echo \
@@ -243,7 +243,7 @@ if [ -n "$add_modules" ]; then
 elif [ -n "$remove_modules" ]; then
     read_modules_list || exit 1
     if [ ${#modules[@]} -gt 0 ]; then
-	krels=($(ls /lib/modules/ | /usr/lib/rpm/rpmsort -r))
+	krels=($(ls /lib/modules/ | "$(dirname "$0")/luarpmsort" | tac))
 	for krel in "${krels[@]}"; do
 	    [ -e /boot/symvers-$krel.gz ] || continue
 	    for ((n = 0; n < ${#modules[@]}; n++)); do
@@ -281,7 +281,7 @@ elif [ -n "$add_kernel" ]; then
 	     "not found" >&2
 	exit 1
     fi
-    for krel in $(ls /lib/modules/ | /usr/lib/rpm/rpmsort -r); do
+    for krel in $(ls /lib/modules/ | "$(dirname "$0")/luarpmsort" | tac); do
 	[ "$add_krel" = "$krel" ] && continue
 	[ -d /lib/modules/$krel/updates ] || continue
 	for module in $(find /lib/modules/$krel/updates -name '*.ko'); do

--- a/weak-modules
+++ b/weak-modules
@@ -225,7 +225,7 @@ if [ -n "$add_modules" ]; then
 		    if [ "$weak_krel" != "$module_krel" ] &&
 		       [ "$(printf "%s\n" "$weak_krel" "$module_krel" \
 			    | "$(dirname "$0")/luarpmsort" | head -n 1)" = \
-			 "$module_krel" ]; then
+			 "$weak_krel" ]; then
 			# Keep modules from more recent kernels.
 			[ -n "$verbose" ] && echo \
 "Keeping module ${module##*/} from kernel $weak_krel for kernel $krel"
@@ -243,7 +243,7 @@ if [ -n "$add_modules" ]; then
 elif [ -n "$remove_modules" ]; then
     read_modules_list || exit 1
     if [ ${#modules[@]} -gt 0 ]; then
-	krels=($(ls /lib/modules/ | "$(dirname "$0")/luarpmsort" | tac))
+	krels=($(ls /lib/modules/ | "$(dirname "$0")/luarpmsort"))
 	for krel in "${krels[@]}"; do
 	    [ -e /boot/symvers-$krel.gz ] || continue
 	    for ((n = 0; n < ${#modules[@]}; n++)); do
@@ -281,7 +281,7 @@ elif [ -n "$add_kernel" ]; then
 	     "not found" >&2
 	exit 1
     fi
-    for krel in $(ls /lib/modules/ | "$(dirname "$0")/luarpmsort" | tac); do
+    for krel in $(ls /lib/modules/ | "$(dirname "$0")/luarpmsort"); do
 	[ "$add_krel" = "$krel" ] && continue
 	[ -d /lib/modules/$krel/updates ] || continue
 	for module in $(find /lib/modules/$krel/updates -name '*.ko'); do

--- a/weak-modules2
+++ b/weak-modules2
@@ -285,7 +285,6 @@ find_kmps() {
     printf "%s\n" $tmpdir/basenames-* \
     | sed -re "s:$tmpdir/basenames-::" \
     | "$(dirname "$0")/luarpmsort" \
-    | tac \
     > $tmpdir/kmps
 }
 

--- a/weak-modules2
+++ b/weak-modules2
@@ -284,7 +284,8 @@ find_kmps() {
 
     printf "%s\n" $tmpdir/basenames-* \
     | sed -re "s:$tmpdir/basenames-::" \
-    | /usr/lib/rpm/rpmsort -r \
+    | "$(dirname "$0")/luarpmsort" \
+    | tac \
     > $tmpdir/kmps
 }
 


### PR DESCRIPTION
Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1164553

Warning: COMPLETELY UNTESTED! Please tell me how to test this and I'll try to do that.

An alternative to using this new `luarpmsort` script would be to just ship a copy of the old `/usr/lib/rpm/rpmsort`, but that doesn't handle `^` and `~` properly.