### PR TITLE
luarpmsort: add -r option

### DIFF
--- a/driver-check.sh
+++ b/driver-check.sh
@@ -3,6 +3,7 @@
 VERSION="0.6"
 MAINTAINER="Martin Wilck <mwilck@suse.com>"
 USAGE="Usage: ${0##*/} [-o|--out output-file]"
+RPMSORT="$(dirname "$0")/luarpmsort"
 
 errors=0
 warnings=0
@@ -301,7 +302,7 @@ check_rpm "$smt"
 mkdir -p "$tmp/rpms"
 found_kernel=false
 for rpm in $(rpm -qa --qf '%{n}-%{v}-%{r}\n' 'kernel-*' '*-kmp-*' | \
-		"$(dirname "$0")/luarpmsort" | tac); do
+		"$RPMSORT"); do
 	case "$rpm" in
 	kernel-source-* | kernel-syms-* | kernel-*-debug* | kernel-*-man-* | \
 	kernel-*-devel-* | kernel-firmware-* | kernel-coverage-* | \

--- a/luarpmsort
+++ b/luarpmsort
@@ -1,6 +1,6 @@
 #!/bin/bash
 rpmsort() {
-        direction=$1
+	direction=$1
 	script='
 function parse(ver)
 	local epoch, version, release = 0, ver, 0
@@ -43,24 +43,28 @@ print(table.concat(vers, "\n"))
 }
 
 usage() {
-    cat >&2 <<EOF
-$0 - sort standard input according to rpm version sorting conventions,
-     using rpm's built-in lua interpreter
+	cat >&2 <<EOF
+$0 - sort input according to rpm version sorting conventions
+
+Expects rpm package versions separated by newlines as input and outputs
+them sorted according to rpm version sorting conventions, with old versions
+at the top.
+
 Options:
 	-r|--reverse	sort backwards
 	-h|--help	print this help
 EOF
-    exit 0
+	exit 0
 }
 
 DIRECTION=-1
 while [[ $# -gt 0 ]]; do
-    case $1 in
-	-r|--reverse) DIRECTION=1;;
-	-h|--help) usage;;
-	*)  echo "$0: invalid parameter $1 ignored" >&2;;
-    esac
-    shift
+	case $1 in
+		-r|--reverse) DIRECTION=1;;
+		-h|--help) usage;;
+		*)  echo "$0: invalid parameter $1 ignored" >&2;;
+	esac
+	shift
 done
 
 rpmsort "$DIRECTION"

--- a/luarpmsort
+++ b/luarpmsort
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Note: Unlike the old rpmsort, newer versions are at the top!
 rpmsort() {
+        direction=$1
 	script='
 function parse(ver)
 	local epoch, version, release = 0, ver, 0
@@ -29,17 +29,38 @@ function pkgvercmp(a, b)
 	if vcmp ~= 0 then return vcmp end
 
 	return rpm.vercmp(ar, br)
-end	
+end
 
 vers = {}
 for line in io.stdin:lines() do
 	table.insert(vers, line)
 end
-table.sort(vers, function(a, b) return pkgvercmp(a, b) == 1 end)
+table.sort(vers, function(a, b) return pkgvercmp(a, b) == '"$direction"' end)
 print(table.concat(vers, "\n"))
 '
 
 	rpm --eval "%{lua: ${script}}"
 }
 
-rpmsort
+usage() {
+    cat >&2 <<EOF
+$0 - sort standard input according to rpm version sorting conventions,
+     using rpm's built-in lua interpreter
+Options:
+	-r|--reverse	sort backwards
+	-h|--help	print this help
+EOF
+    exit 0
+}
+
+DIRECTION=-1
+while [[ $# -gt 0 ]]; do
+    case $1 in
+	-r|--reverse) DIRECTION=1;;
+	-h|--help) usage;;
+	*)  echo "$0: invalid parameter $1 ignored" >&2;;
+    esac
+    shift
+done
+
+rpmsort "$DIRECTION"

--- a/weak-modules
+++ b/weak-modules
@@ -5,6 +5,7 @@
 # packages
 
 unset LANG LC_ALL LC_COLLATE
+RPMSORT="$(dirname "$0")/luarpmsort"
 
 NM=
 if command -v nm >/dev/null; then
@@ -224,8 +225,8 @@ if [ -n "$add_modules" ]; then
 		    weak_krel=$(krel_of_module "$weak_module")
 		    if [ "$weak_krel" != "$module_krel" ] &&
 		       [ "$(printf "%s\n" "$weak_krel" "$module_krel" \
-			    | "$(dirname "$0")/luarpmsort" | head -n 1)" = \
-			 "$weak_krel" ]; then
+			    | "$RPMSORT" | head -n 1)" = \
+			 "$module_krel" ]; then
 			# Keep modules from more recent kernels.
 			[ -n "$verbose" ] && echo \
 "Keeping module ${module##*/} from kernel $weak_krel for kernel $krel"
@@ -243,7 +244,7 @@ if [ -n "$add_modules" ]; then
 elif [ -n "$remove_modules" ]; then
     read_modules_list || exit 1
     if [ ${#modules[@]} -gt 0 ]; then
-	krels=($(ls /lib/modules/ | "$(dirname "$0")/luarpmsort"))
+	krels=($(ls /lib/modules/ | "$RPMSORT" -r))
 	for krel in "${krels[@]}"; do
 	    [ -e /boot/symvers-$krel.gz ] || continue
 	    for ((n = 0; n < ${#modules[@]}; n++)); do
@@ -281,7 +282,7 @@ elif [ -n "$add_kernel" ]; then
 	     "not found" >&2
 	exit 1
     fi
-    for krel in $(ls /lib/modules/ | "$(dirname "$0")/luarpmsort"); do
+    for krel in $(ls /lib/modules/ | "$RPMSORT" -r); do
 	[ "$add_krel" = "$krel" ] && continue
 	[ -d /lib/modules/$krel/updates ] || continue
 	for module in $(find /lib/modules/$krel/updates -name '*.ko'); do

--- a/weak-modules2
+++ b/weak-modules2
@@ -56,6 +56,8 @@
 # kmps: list of kmps, newest first
 #
 
+RPMSORT="$(dirname "$0")/luarpmsort"
+
 find_depmod() {
     local _d
 
@@ -284,7 +286,7 @@ find_kmps() {
 
     printf "%s\n" $tmpdir/basenames-* \
     | sed -re "s:$tmpdir/basenames-::" \
-    | "$(dirname "$0")/luarpmsort" \
+    | "$RPMSORT" -r \
     > $tmpdir/kmps
 }
 


### PR DESCRIPTION
This allows us to use luarpmsort like the legacy rpmsort program.
Also, set RPMSORT variable once in all scripts that use it.