### PR TITLE
Remove more SUSE INITRD instructions

### DIFF
--- a/modprobe.conf/modprobe.conf.common
+++ b/modprobe.conf/modprobe.conf.common
@@ -71,18 +71,10 @@ blacklist pata_acpi
 softdep uhci-hcd pre: ehci-hcd
 softdep ohci-hcd pre: ehci-hcd
 
-# libcrc32c calls crypto_alloc_shash("crc32c", 0, 0), which results in a
-# request_module("crc32c"), but that dependency is not seen by modpost/depmod
-# https://bugzilla.novell.com/552443
-# SUSE INITRD: libcrc32c REQUIRES crc32c
-
-# likewise, cifs calls crypto_alloc_shash(...) for a couple of algorithms
-# https://bugzilla.novell.com/730617
-# SUSE INITRD: cifs REQUIRES des ecb md4 md5 hmac arc4
-# It also calls load_nls()
+# cifs calls load_nls()
 # FIXME: determine the proper nls module based on fstab options instead
-# SUSE INITRD: cifs REQUIRES nls_utf8
- 
+softdep nls pre: cifs: nls_utf8
+
 # SCSI changers can take 1h to initialize on module load,
 # triggering udev timeouts (bnc#760274).
 options ch init=0


### PR DESCRIPTION
- crc32c is now an implicit softdep of libcrc32
- cifs automatically has the relevant dependencies, as does the dracut module
- libcrc32c now has crc32c as a soft-pre in its own right
- nls is compiled in, but nls_utf8 is still needed. However, it
  can be provided as a pure soft-pre now

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1171065.