### PR TITLE
spec: rework dependencies

### DIFF
--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -36,12 +36,15 @@ Group:          System/Base
 URL:            https://github.com/openSUSE/suse-module-tools
 Source0:        %{name}-%{version}.tar.xz
 Source1:        %{name}.rpmlintrc
+Requires:       /usr/bin/grep
+Requires:       /usr/bin/gzip
+Requires:       /usr/bin/sed
 Requires:       coreutils
 Requires:       findutils
-Requires:       grep
-Requires:       gzip
 Requires:       rpm
-Requires:       sed
+Requires(post): /usr/bin/grep
+Requires(post): /usr/bin/sed
+Requires(post): coreutils
 # Use weak dependencies for mkinitrd and kmod in order to
 # keep Ring0 lean. In normal deployments, these packages
 # will be available anyway.


### PR DESCRIPTION
Make sure required packages for %post install are already installed at that
time. Use file requires where possible to be able to reduce system size for
small OS.