### PR TITLE
spec file: Drop SLE11 compatibility.

### DIFF
--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -49,11 +49,7 @@ Requires(post): coreutils
 # keep Ring0 lean. In normal deployments, these packages
 # will be available anyway.
 Recommends:     dracut
-%if 0%{?suse_version} >= 1315
 Recommends:     kmod
-%else
-Recommends:     modutils
-%endif
 # This release requires the dracut fix for bsc#1127891
 Conflicts:      dracut < 44.2
 


### PR DESCRIPTION
We now don't support mkinitrd so we can't run on SLE11 with modutils.