### PR TITLE
weak-modules2: dlog must not return error

### DIFF
--- a/weak-modules2
+++ b/weak-modules2
@@ -93,10 +93,12 @@ find_depmod() {
 
 log() {
     [ $opt_verbose -gt 0 ] && echo "$@" >&2
+    return 0
 }
 
 dlog() {
     [ $opt_verbose -gt 1 ] && echo "$@" >&2
+    return 0
 }
 
 doit() {


### PR DESCRIPTION
It's sometimes called last in other function so a return value != 0
would make those other function fail