### PR TITLE
weak-modules2: handle kernel modules in /usr/lib/modules

### DIFF
--- a/weak-modules
+++ b/weak-modules
@@ -95,7 +95,7 @@ read_modules_list() {
 	    module_krels[n]=$(krel_of_module "${modules[n]}")
 	else
 	    # Try to extract the kernel release from the path
-	    set -- "${modules[n]#/lib/modules/}"
+	    set -- "${modules[n]#*/lib/modules/}"
 	    module_krels[n]=${1%%/*}
 	fi
     done
@@ -215,10 +215,10 @@ if [ -n "$add_modules" ]; then
 		module=${modules[n]}
 		module_krel=${module_krels[n]}
 		case "$module" in
-		/lib/modules/$krel/*)
+		*/lib/modules/$krel/*)
 		    continue ;;
 		esac
-		subpath=${module#/lib/modules/$module_krel/updates}
+		subpath=${module#*/lib/modules/$module_krel/updates}
 		weak_module=/lib/modules/$krel/weak-updates/${subpath#/}
 		if [ -r "$weak_module" ]; then
 		    weak_krel=$(krel_of_module "$weak_module")
@@ -250,7 +250,7 @@ elif [ -n "$remove_modules" ]; then
 		module=${modules[n]}
 		[ -e "$module" ] && continue
 		module_krel=${module_krels[n]}
-		subpath=${module#/lib/modules/$module_krel/updates}
+		subpath=${module#*/lib/modules/$module_krel/updates}
 		weak_module=/lib/modules/$krel/weak-updates/${subpath#/}
 		if [ "$(readlink "$weak_module")" = "$module" ]; then
 		    [ -n "$verbose" ] && echo \
@@ -285,7 +285,7 @@ elif [ -n "$add_kernel" ]; then
 	[ "$add_krel" = "$krel" ] && continue
 	[ -d /lib/modules/$krel/updates ] || continue
 	for module in $(find /lib/modules/$krel/updates -name '*.ko'); do
-	    subpath=${module#/lib/modules/$krel/updates}
+	    subpath=${module#*/lib/modules/$krel/updates}
 	    weak_module=/lib/modules/$add_krel/weak-updates/${subpath#/}
 	    [ -e "$weak_module" ] && continue
 	    if module_is_compatible $module $add_krel; then

--- a/weak-modules2
+++ b/weak-modules2
@@ -123,7 +123,7 @@ strip_mod_extensions() {
 symlink_to_module() {
     local module=$1 krel=$2
 
-    echo /lib/modules/$krel/weak-updates/${module#/lib/modules/*/}
+    echo /lib/modules/$krel/weak-updates/${module#*/lib/modules/*/}
 }
 
 # Is a kmp already present in or linked to from this kernel?
@@ -286,7 +286,7 @@ check_kmp() {
     local kmp=$1
 
     # Make sure all modules are for the same kernel
-    set -- $(sed -re 's:^/lib/modules/([^/]+)/.*:\1:' \
+    set -- $(sed -re 's:^.*/lib/modules/([^/]+)/.*:\1:' \
 		 $tmpdir/modules-$kmp \
 	     | sort -u)
     if [ $# -ne 1 ]; then
@@ -298,7 +298,7 @@ check_kmp() {
     dlog "check_kmp: $kmp contains modules for $1"
 
     # Make sure none of the modules are in kernel/ or weak-updates/
-    if grep -qE -e '^/lib/modules/[^/]+/(kernel|weak-updates)/' \
+    if grep -qE -e '^.*/lib/modules/[^/]+/(kernel|weak-updates)/' \
 	    $tmpdir/modules-$kmp; then
 	echo "Error: package $kmp must not install modules into " \
 	     "kernel/ or weak-updates/" >&2
@@ -323,7 +323,7 @@ find_kmps() {
 	    continue
 	fi
 	rpm -ql --nodigest --nosignature "$kmp" \
-	    | grep -Ee '^/lib/modules/[^/]+/.+\.ko(\.[gx]z|\.zst)?$' \
+	    | grep -Ee '^.*/lib/modules/[^/]+/.+\.ko(\.[gx]z|\.zst)?$' \
 	    > $tmpdir/modules-$kmp
 	if [ $? != 0 ]; then
 	    echo "WARNING: $kmp does not contain any kernel modules" >&2


### PR DESCRIPTION
On the input side the script needs to handle /usr/lib/modules. When
checking in the file system it does not necessarily have to as /lib
link to /usr/lib. So as long as the script potentially has to deal with
both locations it's ok to poke around in /lib to keep the code simple.
As soon as we only need to handle /usr/lib all occurrences can be
replaced.