### PR TITLE
weak-modules2: accept modules under /usr/lib/modules on stdin

### DIFF
--- a/weak-modules2
+++ b/weak-modules2
@@ -323,7 +323,7 @@ find_kmps() {
 	    continue
 	fi
 	rpm -ql --nodigest --nosignature "$kmp" \
-	    | grep -Ee '^/lib/modules/[^/]+/.+\.ko(\.[gx]z|\.zst)?$' \
+	    | sed -nr 's:^(/usr)?(/lib/modules/[^/]+/.+\.ko)(\.[gx]z|\.zst)?$:\2\3:p' \
 	    > $tmpdir/modules-$kmp
 	if [ $? != 0 ]; then
 	    echo "WARNING: $kmp does not contain any kernel modules" >&2
@@ -608,7 +608,7 @@ remove_kmp() {
 
     # Read the list of module names from standard input
     # (This kmp may already have been removed!)
-    cat > $tmpdir/modules-$kmp
+    sed 's:^/usr::' > $tmpdir/modules-$kmp
     check_kmp "$kmp" || return 1
 
     local dir krel status


### PR DESCRIPTION
This logic relies on the assumption that /lib/modules always resolves
to /usr/lib/modules. wm2 continues to work with /lib/modules only,
internally. All symlinks created will point to files under /lib/modules.

Thus the only point in the code where we need to account for /usr is
when we read the list of modules from stdin, and there we simply strip
off the /usr prefix, knowing that the result will still resolve to the
same file.