### PR TITLE
testing optimizations for labsconf 2021 talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,16 @@ details.
 
 Use the following environment variables:
 
- * WM2_VERBOSE: value from 0 (default, no logging) - 3 (tracing).
+ * `WM2_VERBOSE:` value from 0 (default, no logging) - 3 (tracing).
    the -v/--verbose option increases log level by one.
- * WM2_DEBUG: 0 (default) or 1. Enables verbose output of certain
+ * `WM2_DEBUG`: 0 (default) or 1. Enables verbose output of certain
    commands called by weak-modules2. Equivalent to --debug.
- * WM2_LOGFILE: redirect the output to the given file.
+ * `WM2_LOGFILE`: redirect the output to the given file.
+
+### Other environment variables
+
+ * `WM2_DEPMOD_INC`: set this to a non-empty string to enable the experimental
+   "incremental depmod" feature. This will speed up KMP installations.
 
 ## Kernel scriptlet files
 

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -285,6 +285,9 @@ EOF
 	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@"
 	;;
     posttrans)
+	if test -x /usr/lib/module-init-tools/regenerate-initrd-posttrans; then
+	    /bin/bash -c 'set +e; /usr/lib/module-init-tools/regenerate-initrd-posttrans' || script_rc=$?
+	fi
 	;;
     *)
 	echo Unknown scriptlet "$op" >&2

--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -36,12 +36,19 @@ for f in "$dir"/*; do
 	break
 done
 
-if test -e "$dir/all"; then
-	rm "$dir"/*
-	"$DRACUT" -f --regenerate-all
-	exit
-fi
 err=0
+if test -e "$dir/all"; then
+    rm "$dir"/*
+    for f in /lib/modules/*; do
+	[ -f "$f/modules.dep" ] || [ -f "$f/modules.dep.bin" ] || continue
+	kver=${f##*/}
+	if ! "$DRACUT" -f "/boot/initrd-$kver" "$kver"; then
+		err=$?
+	fi
+    done
+    exit $err
+fi
+
 for f in "$dir"/*; do
 	case $f in
 	    "$dir/*")

--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -36,17 +36,57 @@ for f in "$dir"/*; do
 	break
 done
 
+tmpdir=$(mktemp -d /var/tmp/r-i-p-XXXXXX)
+[ -n "$tmpdir" ] && [ -d "$tmpdir" ] || {
+    echo "error: failed to create temporary directory" >&2
+    exit 1
+}
+trap 'rm -rf "$tmpdir"' 0
+
+start_dracut() {
+    local kver=$1 x pid
+    if [ x"$RIP_PARALLEL" != x1 ]; then
+	if ! "$DRACUT" -f "/boot/initrd-$kver" "$kver"; then
+	    err=$?
+	fi
+    else
+	"$DRACUT" -f "/boot/initrd-$kver" "$kver" >"$tmpdir/dracut-$kver.log" 2>&1 &
+	pid=$!
+	echo "$DRACUT started for $kver with pid $pid" >&2
+	ln -s dracut-$kver.log "$tmpdir/$pid.log"
+	PIDS="$PIDS $pid"
+    fi
+}
+
+wait_for_dracut() {
+    local pid err=$1
+
+    for pid in $PIDS; do
+	wait $pid
+	if [ $? -ne 0 ]; then
+	    err=$?
+	    echo "$DRACUT($pid) failed" >&2
+	else
+	    echo "$DRACUT($pid) successful" >&2
+	fi
+	[[ ! -f "$tmpdir/$pid.log" ]] || cat "$tmpdir/$pid.log"
+    done
+    return $err
+}
+
 err=0
+PIDS=""
+
 if test -e "$dir/all"; then
     rm "$dir"/*
+    PIDS=""
     for f in /lib/modules/*; do
 	[ -f "$f/modules.dep" ] || [ -f "$f/modules.dep.bin" ] || continue
 	kver=${f##*/}
-	if ! "$DRACUT" -f "/boot/initrd-$kver" "$kver"; then
-		err=$?
-	fi
+	start_dracut "$kver"
     done
-    exit $err
+    wait_for_dracut "$err"
+    exit $?
 fi
 
 for f in "$dir"/*; do
@@ -60,8 +100,7 @@ for f in "$dir"/*; do
 	    echo $0: skippping invalid kernel version "$dir/$kver"
 	    continue
 	}
-	if ! "$DRACUT" -f --kver "$kver"; then
-		err=$?
-	fi
+	start_dracut "$kver"
 done
-exit $err
+wait_for_dracut "$err"
+exit $?

--- a/weak-modules2
+++ b/weak-modules2
@@ -697,10 +697,72 @@ remove_kernel_modules() {
     kernel_changed "$krel" "" "" </dev/null
 }
 
+add_kmp_for_krel() {
+    local kmp=$1 krel=$2
+    local dir krel status=0 old_kmp syml=()
+
+    dlog "add_kmp: processing $kmp for $krel"
+
+    # The following call to has_unresolved_symbols() would just produce
+    # a warning, in a case that shouldn't occur in a properly configured
+    # system anyway. It could be skipped with no significant feature loss.
+    # But there's a strange performance phenomenon: has_unresolved_symbols()
+    # (i.e. a full depmod run) normally takes ~10s if the module files
+    # aren't in the page cache. Follow-up depmod calls take ~2s only for
+    # zstd-compressed modules. If we skip the call below,
+    # has_unresolved_symbols() will be called later on a temporary copy of
+    # /lib/modules/$krel, where almost all files and directories are
+    # symlinks into the "real" /lib/modules/$krel (see create_temporary_modules_dir()
+    # above). In my tests, the depmod call on the temporary directory
+    # consistently took 30s! The bottom line is that doing this extra
+    # depmod call speeds up the execution of weak_modules2, although it
+    # needs 10 extra seconds in the first place.  If $WM2_DEPMOD_INC is
+    # set, this call has no effect; skip it.
+    if [[ ! $WM2_DEPMOD_INC ]] && opt_debug=1 has_unresolved_symbols "$krel" "/"; then
+	echo "Warning: /lib/modules/$krel is inconsistent" >&2
+	echo "Warning: weak-updates symlinks might not be created" >&2
+    fi
+
+    if kmp_is_present "$kmp" "$krel"; then
+	log "Package $kmp does not need to be added to kernel $krel"
+	run_depmod "$krel" && \
+	    build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
+			 <"$tmpdir/basenames-$kmp" || \
+		status=1
+	return "$status"
+    fi
+
+    old_kmp=$(previous_version_of_kmp "$kmp" "$krel")
+    make_module_symlinks "$krel" / "$kmp" syml
+
+    if can_replace_kmp "$old_kmp" "$kmp" "$krel"; then
+	remove_kmp_modules "$old_kmp" "$krel"
+	add_kmp_modules "$kmp" "$krel"
+	if [ -z "$old_kmp" ]; then
+	    log "Package $kmp added to kernel $krel"
+	    run_depmod "$krel" "${syml[@]}" && \
+		build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
+			     <"$tmpdir/basenames-$kmp" || \
+		    status=1
+	else
+	    log "Package $old_kmp replaced by package $kmp in kernel $krel"
+	    run_depmod "$krel" "${syml[@]}" && \
+		cat "$tmpdir/basenames-{$old_kmp,$kmp}" \
+		    | build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" || \
+		    status=1
+	fi
+    elif [[ $old_kmp ]]; then
+	log "Package $old_kmp kept in kernel $krel (not replaced by $kmp)"
+    else
+	echo "FAILED to add $kmp in kernel $krel" >&2
+    fi
+    return "$status"
+}
+
 add_kmp() {
     local kmp=$1 kmpshort=${1%-*-*}
     local basename=${kmpshort%-kmp-*} flavor=${kmpshort##*-}
-    local system_map dir krel status old_kmp syml=()
+    local system_map PIDS=() pid status=0
 
     # Find the kmp to be added as well as any previous versions
     find_kmps "$basename" "$flavor" || return 1
@@ -713,70 +775,68 @@ add_kmp() {
         *)
             continue
         esac
-	dlog "add_kmp: processing $kmp for $krel"
-	[ -d $dir ] || continue
+	[[ -d "$dir" ]] || continue
 	system_map=$(find_usrmerge_boot System.map "$krel")
-	[ -n "$system_map" ] || continue
-
-	# The following call to has_unresolved_symbols() would just produce
-	# a warning, in a case that shouldn't occur in a properly configured
-	# system anyway. It could be skipped with no significant feature loss.
-	# But there's a strange performance phenomenon: has_unresolved_symbols()
-	# (i.e. a full depmod run) normally takes ~10s if the module files
-	# aren't in the page cache. Follow-up depmod calls take ~2s only for
-	# zstd-compressed modules. If we skip the call below,
-	# has_unresolved_symbols() will be called later on a temporary copy of
-	# /lib/modules/$krel, where almost all files and directories are
-	# symlinks into the "real" /lib/modules/$krel (see create_temporary_modules_dir()
-	# above). In my tests, the depmod call on the temporary directory
-	# consistently took 30s! The bottom line is that doing this extra
-	# depmod call speeds up the execution of weak_modules2, although it
-	# needs 10 extra seconds in the first place.  If $WM2_DEPMOD_INC is
-	# set, this call has no effect; skip it.
-	if [[ ! $WM2_DEPMOD_INC ]] && opt_debug=1 has_unresolved_symbols "$krel" "/"; then
-	    echo "Warning: /lib/modules/$krel is inconsistent" >&2
-	    echo "Warning: weak-updates symlinks might not be created" >&2
-	fi
-	if kmp_is_present $kmp $krel; then
-	    log "Package $kmp does not need to be added to kernel $krel"
-	    run_depmod "$krel" && \
-		build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
-			     <"$tmpdir/basenames-$kmp" || \
-		    status=1
-	    continue
-	fi
-	old_kmp=$(previous_version_of_kmp "$kmp" "$krel")
-	make_module_symlinks "$krel" / "$kmp" syml
-
-	if can_replace_kmp "$old_kmp" "$kmp" "$krel"; then
-	    remove_kmp_modules "$old_kmp" "$krel"
-	    add_kmp_modules "$kmp" "$krel"
-	    if [ -z "$old_kmp" ]; then
-		log "Package $kmp added to kernel $krel"
-		run_depmod "$krel" "${syml[@]}" && \
-		    build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
-				 <"$tmpdir/basenames-$kmp" || \
-			status=1
-	    else
-		log "Package $old_kmp replaced by package $kmp in kernel $krel"
-		run_depmod "$krel" "${syml[@]}" && \
-		    cat "$tmpdir/basenames-{$old_kmp,$kmp}" \
-			| build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" || \
-			status=1
-	    fi
-	elif [[ $old_kmp ]]; then
-	    log "Package $old_kmp kept in kernel $krel (not replaced by $kmp)"
+	[[ $system_map ]] || continue
+	if [[ $WM2_PARALLEL ]]; then
+	    add_kmp_for_krel "$kmp" "$krel" &
+	    PIDS=("${PIDS[@]}" "$!")
 	else
-	    echo "FAILED to add $kmp in kernel $krel" >&2
+	    add_kmp_for_krel "$kmp" "$krel" || status=1
 	fi
     done
+    for pid in "${PIDS[@]}"; do
+	wait "$pid" || status=1
+    done
     dlog "add_kmp: status=$status"
-    return $status
+    return "$status"
+}
+
+remove_kmp_from_krel() {
+    local kmp=$1 krel=$2 status=0
+
+    dlog "remove_kmp: processing $kmp for $krel"
+    if kmp_is_present "$kmp" "$krel"; then
+	local other_found=0 other_kmp
+
+        if [ "$krel" != "$(cat $tmpdir/krel-$kmp)" ]; then
+            remove_kmp_modules "$kmp" "$krel"
+        fi
+
+	while read other_kmp; do
+	    [ "$kmp" != "$other_kmp" ] || continue
+
+	    other_found=1
+	    dlog "remove_kmp: checking other KMP $other_kmp"
+	    if can_replace_kmp "" "$other_kmp" "$krel"; then
+		add_kmp_modules "$other_kmp" "$krel"
+		break
+	    fi
+	done < $tmpdir/kmps
+	if [ -n "$other_kmp" ]; then
+	    log "Package $kmp replaced by package $other_kmp in kernel $krel"
+	    run_depmod "$krel" && \
+		cat $tmpdir/basenames-{$kmp,$other_kmp} \
+		    | build_initrd "$krel" "" "$(may_delay_on_removal "$krel")" || \
+		    status=1
+	else
+	    log "Package $kmp removed from kernel $krel"
+	    if [ $other_found -eq 1 ]; then
+		log "Weak-updates symlinks to no other $kmpshort package could be created"
+	    fi
+	    run_depmod "$krel" && \
+		build_initrd "$krel" "" "$(may_delay_on_removal "$krel")" \
+			     <$tmpdir/basenames-$kmp || \
+		    status=1
+	fi
+    fi
+    return "$status"
 }
 
 remove_kmp() {
     local kmp=$1 kmpshort=${1%-*-*}
     local basename=${kmpshort%-kmp-*} flavor=${kmpshort##*-}
+    local system_map PIDS=() pid
 
     # Find any previous versions of the same kmp
     find_kmps "$basename" "$flavor" || return 1
@@ -795,45 +855,18 @@ remove_kmp() {
         *)
             continue
         esac
-	[ -d $dir ] || continue
+	[[ -d "$dir" ]] || continue
 	system_map=$(find_usrmerge_boot System.map "$krel")
-	[ -n "$system_map" ] || continue
-	dlog "remove_kmp: processing $kmp for $krel"
-	if kmp_is_present $kmp $krel; then
-	    local other_found=0
-
-            if [ $krel != "$(cat $tmpdir/krel-$kmp)" ]; then
-                remove_kmp_modules "$kmp" "$krel"
-            fi
-
-	    local other_kmp
-	    while read other_kmp; do
-		[ "$kmp" != "$other_kmp" ] || continue
-
-		other_found=1
-		dlog "remove_kmp: checking other KMP $other_kmp"
-		if can_replace_kmp "" "$other_kmp" "$krel"; then
-		    add_kmp_modules "$other_kmp" "$krel"
-		    break
-		fi
-	    done < $tmpdir/kmps
-	    if [ -n "$other_kmp" ]; then
-		log "Package $kmp replaced by package $other_kmp in kernel $krel"
-		run_depmod "$krel" && \
-		    cat $tmpdir/basenames-{$kmp,$other_kmp} \
-			| build_initrd "$krel" "" "$(may_delay_on_removal "$krel")" || \
-			status=1
-	    else
-		log "Package $kmp removed from kernel $krel"
-		if [ $other_found -eq 1 ]; then
-		    log "Weak-updates symlinks to no other $kmpshort package could be created"
-		fi
-		run_depmod "$krel" && \
-		    build_initrd "$krel" "" "$(may_delay_on_removal "$krel")" \
-				 <$tmpdir/basenames-$kmp || \
-			status=1
-	    fi
+	[[ $system_map ]] || continue
+	if [[ $WM2_PARALLEL ]]; then
+	    remove_kmp_from_krel "$kmp" "$krel" &
+	    PIDS=("${PIDS[@]}" "$!")
+	else
+	    remove_kmp_from_krel "$kmp" "$krel" || status=1
 	fi
+    done
+    for pid in "${PIDS[@]}"; do
+	wait "$pid" || status=1
     done
     dlog "remove_kmp: status=$status"
     return $status

--- a/weak-modules2
+++ b/weak-modules2
@@ -129,6 +129,7 @@ doit() {
     else
 	:
     fi
+    log "Done $1"
 }
 
 strip_mod_extensions() {
@@ -231,7 +232,9 @@ has_unresolved_symbols() {
 	    echo "WARNING: System.map not found for $krel, symbol resolution may fail" >&2
 	fi
     fi
+    log "$DEPMOD -b $basedir -ae ${args[@]} $krel"
     output="$("$DEPMOD" -b "$basedir" -ae "${args[@]}" $krel 2>&1)"
+    log "$DEPMOD finished"
     status=$?
     if [ $status -ne 0 ]; then
 	echo "$output" >&2
@@ -391,7 +394,7 @@ previous_version_of_kmp() {
 }
 
 get_initrd_basenames() {
-    $LSINITRD /boot/initrd-$1 | \
+    doit $LSINITRD /boot/initrd-$1 | \
 	sed -rn 's:.*\<lib/modules/.*/::p' | \
 	strip_mod_extensions
 
@@ -744,7 +747,7 @@ usage() {
 
 ##############################################################################
 
-save_argv=("$@")
+echo "weak-modules2 startup" >&2
 options=`getopt -o vh --long add-kernel,remove-kernel,add-kmp,remove-kmp \
                       --long add-kernel-modules,remove-kernel-modules \
 		      --long usage,help,verbose,dry-run,debug,logfile: -- "$@"`
@@ -869,4 +872,5 @@ case $mode in
     remove_kmp "$1"
 esac
 
+echo "weak-modules2 finished" >&2
 # vim:shiftwidth=4 softtabstop=4

--- a/weak-modules2
+++ b/weak-modules2
@@ -212,7 +212,8 @@ create_temporary_modules_dir() {
 
 # Check for unresolved symbols
 has_unresolved_symbols() {
-    local krel=$1 basedir=$2 output status args sym_errors _f
+    local krel=$1 basedir=$2 kmp=$3 kmp_mods=()
+    local output status args sym_errors _f
 
     if [ ! -e "$tmpdir/symvers-$krel" ]; then
 	_f=$(find_usrmerge_boot symvers "$krel" gz)
@@ -221,8 +222,8 @@ has_unresolved_symbols() {
 	    zcat "$_f" >"$tmpdir/symvers-$krel"
 	fi
     fi
-    if [ -e $tmpdir/symvers-$krel ]; then
-	args=(-E $tmpdir/symvers-$krel)
+    if [ -e "$tmpdir/symvers-$krel" ]; then
+	args=(-E "$tmpdir/symvers-$krel")
     else
 	echo "WARNING: symvers.gz not found for $krel, symbol resolution will be unreliable" >&2
 	_f=$(find_usrmerge_boot System.map "$krel")
@@ -232,10 +233,25 @@ has_unresolved_symbols() {
 	    echo "WARNING: System.map not found for $krel, symbol resolution may fail" >&2
 	fi
     fi
-    log "$DEPMOD -b $basedir -ae ${args[@]} $krel"
-    output="$("$DEPMOD" -b "$basedir" -ae "${args[@]}" $krel 2>&1)"
-    log "$DEPMOD finished"
-    status=$?
+    if [[ $WM2_DEPMOD_INC && $kmp ]]; then
+	mapfile -t kmp_mods <"$tmpdir/modules-$kmp"
+	# prepend $basedir
+	kmp_mods=("${kmp_mods[@]/#/$basedir}")
+
+	log "$DEPMOD -b $basedir -ae ${args[*]} -I $krel ${kmp_mods[*]}"
+	output="$("$DEPMOD" -I -b "$basedir" -ae "${args[@]}" "$krel" "${kmp_mods[@]}" 2>&1)"
+	status=$?
+	log "$DEPMOD finished"
+    else
+	status=1
+    fi
+    if [[ $status -ne 0 ]]; then
+	# Fallback to full depmod
+	log "$DEPMOD -b $basedir -ae ${args[*]} $krel"
+	output="$("$DEPMOD" -b "$basedir" -ae "${args[@]}" $krel 2>&1)"
+	status=$?
+	log "$DEPMOD finished"
+    fi
     if [ $status -ne 0 ]; then
 	echo "$output" >&2
 	echo "depmod exited with error $status" >&2
@@ -288,7 +304,7 @@ __can_replace_kmp() {
 	return 1
     fi
     doit=1 add_kmp_modules "$new_kmp" "$krel" "$basedir"
-    if has_unresolved_symbols "$krel" "$basedir"; then
+    if has_unresolved_symbols "$krel" "$basedir" "$new_kmp"; then
 	doit=1 remove_kmp_modules "$new_kmp" "$krel" "$basedir"
 	doit=1 add_kmp_modules "$old_kmp" "$krel" "$basedir"
 	return 1

--- a/weak-modules2
+++ b/weak-modules2
@@ -209,6 +209,22 @@ create_temporary_modules_dir() {
            )"
 }
 
+make_module_symlinks() {
+    local krel=$1 basedir=$2 kmp=$3 n
+    local -n symlinks=$4               # nameref!
+
+    if [[ "$basedir" == / ]]; then
+	# avoid double slash //
+	basedir=
+    fi
+    mapfile -t symlinks <"$tmpdir/modules-$kmp"
+    n=0
+    while [[ $n -lt ${#symlinks[@]} ]]; do
+	symlinks[$n]="$basedir$(symlink_to_module "${symlinks[$n]}" "$krel")"
+	: $((n++))
+    done
+}
+
 # Check for unresolved symbols
 has_unresolved_symbols() {
     local krel=$1 basedir=$2 kmp=$3 kmp_mods=()
@@ -233,9 +249,7 @@ has_unresolved_symbols() {
 	fi
     fi
     if [[ $WM2_DEPMOD_INC && $kmp ]]; then
-	mapfile -t kmp_mods <"$tmpdir/modules-$kmp"
-	# prepend $basedir
-	kmp_mods=("${kmp_mods[@]/#/$basedir}")
+	make_module_symlinks "$krel" "$basedir" "$kmp" kmp_mods
 
 	log "$DEPMOD -b $basedir -ae ${args[*]} -I $krel ${kmp_mods[*]}"
 	output="$("$DEPMOD" -I -b "$basedir" -ae "${args[@]}" "$krel" "${kmp_mods[@]}" 2>&1)"
@@ -686,7 +700,7 @@ remove_kernel_modules() {
 add_kmp() {
     local kmp=$1 kmpshort=${1%-*-*}
     local basename=${kmpshort%-kmp-*} flavor=${kmpshort##*-}
-    local system_map dir krel status old_kmp
+    local system_map dir krel status old_kmp syml=()
 
     # Find the kmp to be added as well as any previous versions
     find_kmps "$basename" "$flavor" || return 1
@@ -713,20 +727,20 @@ add_kmp() {
 	    continue
 	fi
 	old_kmp=$(previous_version_of_kmp "$kmp" "$krel")
+	make_module_symlinks "$krel" / "$kmp" syml
+
 	if can_replace_kmp "$old_kmp" "$kmp" "$krel"; then
 	    remove_kmp_modules "$old_kmp" "$krel"
 	    add_kmp_modules "$kmp" "$krel"
 	    if [ -z "$old_kmp" ]; then
 		log "Package $kmp added to kernel $krel"
-		# shellcheck disable=2046
-		run_depmod "$krel" $(cat "$tmpdir/modules-$kmp") && \
+		run_depmod "$krel" "${syml[@]}" && \
 		    build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
 				 <"$tmpdir/basenames-$kmp" || \
 			status=1
 	    else
 		log "Package $old_kmp replaced by package $kmp in kernel $krel"
-		# shellcheck disable=2046
-		run_depmod "$krel" $(cat "$tmpdir/modules-$kmp") && \
+		run_depmod "$krel" "${syml[@]}" && \
 		    cat "$tmpdir/basenames-{$old_kmp,$kmp}" \
 			| build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" || \
 			status=1

--- a/weak-modules2
+++ b/weak-modules2
@@ -666,12 +666,21 @@ may_delay_on_removal() {
 remove_kernel_modules() {
     local krel=$1
 
-    sed -rn '/\.ko(|\.xz|\.gz|\.zst)/p' >$tmpdir/kernel-modules
-    sed 's:.*/::' <$tmpdir/kernel-modules >$tmpdir/kernel-basenames
-
-    # FIXME: remove KMP symlinks that no longer work
-    kernel_changed "$krel" "" "$(may_delay_on_removal "$krel")" \
-		   <$tmpdir/kernel-basenames
+    # We are removing modules here which might be in the initrd.
+    # We can derive kernel-modules and kernel-basenames like we
+    # do in add_kmp_modules. Why don't we do it?
+    # The common case by far is that kernel subpackages are removed
+    # or updated together with the base package. In that case, rebuilding
+    # the initrd in %postun of the subpackage is just a waste, as the
+    # kernel will be uninstalled anyway.
+    #
+    # In %postun we can't figure out whether or not the base package
+    # will also be uninstalled. If it's not, in the worst case, some modules
+    # will be kept in initramfs that are no longer installed on the system
+    # itself. That shouldn't hurt. By not rebuilding the initrd here,
+    # we speed up the common case.
+    cat >/dev/null
+    kernel_changed "$krel" "" "" </dev/null
 }
 
 add_kmp() {

--- a/weak-modules2
+++ b/weak-modules2
@@ -595,10 +595,6 @@ add_kmp() {
 	[ -d $dir ] || continue
 	system_map=$(find_usrmerge_boot System.map "$krel")
 	[ -n "$system_map" ] || continue
-	if opt_debug=1 has_unresolved_symbols "$krel" "/"; then
-	    echo "Warning: /lib/modules/$krel is inconsistent" >&2
-	    echo "Warning: weak-updates symlinks might not be created" >&2
-	fi
 
 	if kmp_is_present $kmp $krel; then
 	    log "Package $kmp does not need to be added to kernel $krel"
@@ -619,8 +615,14 @@ add_kmp() {
 		cat $tmpdir/basenames-{$old_kmp,$kmp} \
 		| run_depmod_build_initrd "$krel" || status=1
 	    fi
+	elif [[ $old_kmp ]]; then
+	    log "Package $old_kmp kept in kernel $krel (not replaced by $kmp)"
 	else
-	    dlog "add_kmp: skipped $kmp"
+	    echo "FAILED to add $kmp in kernel $krel" >&2
+	    if [[ $opt_debug -gt 0 ]] && \
+		   has_unresolved_symbols "$krel" "/"; then
+		echo "Warning: /lib/modules/$krel is inconsistent" >&2
+	    fi
 	fi
     done
     dlog "add_kmp: status=$status"

--- a/weak-modules2
+++ b/weak-modules2
@@ -419,7 +419,9 @@ get_initrd_basenames() {
 }
 
 # test if rebuilding initrd is needed for $krel.
-# stdin - list of changed modules
+# arg 1: kernel version
+# arg 2: if non-empty, assume kernel package (must rebuild)
+# stdin - list of changed modules (if arg 2 is empty)
 needs_initrd() {
     local krel=$1 is_kernel=$2 changed_basenames=() initrd_basenames=() match=()
 
@@ -555,10 +557,13 @@ walk_kmps() {
 }
 
 # first arg - kernel release
+# 2nd arg: is this a base pkg (-> must rebuild initrd)?
 # other args - modules to add, enables depmod incremental
+# stdin: list of module basenames to feed into build_initrd / needs_initrd
 kernel_changed() {
-    local krel=$1 flavor=${1##*-}
+    local krel=$1 is_basepkg=$2 flavor=${1##*-}
     local system_map=$(find_usrmerge_boot System.map "$krel")
+    shift
     shift
 
     if [ -z "$system_map" ]; then
@@ -575,13 +580,13 @@ kernel_changed() {
     fi
 
     run_depmod "$krel" "$@"
-    build_initrd "$krel" initrd_needed </dev/null
+    build_initrd "$krel" $is_basepkg
 }
 
 add_kernel() {
     local krel=$1
 
-    kernel_changed $krel
+    kernel_changed "$krel" initrd_needed
 }
 
 remove_kernel() {
@@ -599,15 +604,19 @@ add_kernel_modules() {
     local krel=$1
 
     sed -rn '/\.ko(|\.xz|\.gz|\.zst)/p' >$tmpdir/kernel-modules
-    kernel_changed "$krel" $(cat $tmpdir/kernel-modules)
+    sed 's:.*/::' <$tmpdir/kernel-modules >$tmpdir/kernel-basenames
+
+    kernel_changed "$krel" initrd_needed $(cat $tmpdir/kernel-modules) <$tmpdir/kernel-basenames
 }
 
 remove_kernel_modules() {
     local krel=$1
-    cat >/dev/null
+
+    sed -rn '/\.ko(|\.xz|\.gz|\.zst)/p' >$tmpdir/kernel-modules
+    sed 's:.*/::' <$tmpdir/kernel-modules >$tmpdir/kernel-basenames
 
     # FIXME: remove KMP symlinks that no longer work
-    kernel_changed "$krel"
+    kernel_changed "$krel" initrd_needed <$tmpdir/kernel-basenames
 }
 
 add_kmp() {

--- a/weak-modules2
+++ b/weak-modules2
@@ -175,9 +175,9 @@ add_kmp_modules() {
     local module symlink
     while read module; do
 	symlink=$(symlink_to_module $module $krel)
-	doit mkdir -p ${opt_debug:+-v} $basedir${symlink%/*} || exit 1
-	doit ln -sf ${opt_debug:+-v} $module $basedir$symlink || exit 1
-	dlog "add_kmp_modules: added $module to $krel"
+	mkdir -p $basedir${symlink%/*} || exit 1
+	ln -sf $module $basedir$symlink || exit 1
+	dlog "add_kmp_modules: added $module to $krel in $basedir"
     done < $tmpdir/modules-$kmp
 }
 
@@ -190,7 +190,7 @@ remove_kmp_modules() {
     local module symlink
     while read module; do
 	symlink=$(symlink_to_module $module $krel)
-	doit rm -f ${opt_debug:+-v} $basedir$symlink
+	rm -f $basedir$symlink
 	dlog "remove_kmp_modules: removed $module from $krel"
     done < $tmpdir/modules-$kmp
 }

--- a/weak-modules2
+++ b/weak-modules2
@@ -133,7 +133,7 @@ doit() {
 }
 
 strip_mod_extensions() {
-    sed -rn '/^_kernel_$/p;s/\.ko(\.[gx]z|\.zst)?$//p'
+    sed -rn 's/\.ko(\.[gx]z|\.zst)?$//p'
 }
 
 # Name of the symlink that makes a module available to a given kernel
@@ -420,9 +420,9 @@ get_initrd_basenames() {
 }
 
 # test if rebuilding initrd is needed for $krel.
-# stdin - list of changed modules ("_kernel_" for the whole kernel)
+# stdin - list of changed modules
 needs_initrd() {
-    local krel=$1
+    local krel=$1 is_kernel=$2 changed_basenames=() initrd_basenames=() match=()
 
     # Don't generate an initrd for kdump here. It's done automatically with mkdumprd when
     # /etc/init.d/boot.kdump is called to load the kdump kernel. See mkdumprd(8) why
@@ -443,23 +443,25 @@ needs_initrd() {
 	return 0
     fi
 
-    local changed_basenames=($(strip_mod_extensions | sort -u))
-    dlog "needs_initrd: changed_basenames: " $changed_basenames
-
-    if [ "$changed_basenames" = "_kernel_" ]; then
+    if [[ $is_kernel ]]; then
 	dlog "needs_initrd: yes, kernel package"
 	return 0
     fi
+
+    mapfile -t changed_basenames < <(strip_mod_extensions | sort -u)
+    dlog "needs_initrd: changed_basenames: ${changed_basenames[*]}"
+
     if [ ! -e /boot/initrd-$krel ]; then
 	dlog "needs_initrd: yes, initrd doesn't exist yet"
 	return 0
     fi
-    local initrd_basenames=($(get_initrd_basenames "$krel" | sort -u))
-    dlog "needs_initrd: initrd_basenames: " $initrd_basenames
-    local i=($(join <(printf '%s\n' "${changed_basenames[@]}") \
-	            <(printf '%s\n' "${initrd_basenames[@]}") ))
-    log "changed initrd modules for kernel $krel: ${i[@]-none}"
-    if [ ${#i[@]} -gt 0 ]; then
+    mapfile -t initrd_basenames < <(get_initrd_basenames "$krel" | sort -u)
+
+    dlog "needs_initrd: initrd_basenames: ${initrd_basenames[*]}"
+    mapfile -t match < <(join <(printf '%s\n' "${changed_basenames[@]}") \
+			      <(printf '%s\n' "${initrd_basenames[@]}") )
+    log "changed initrd modules for kernel $krel: ${match[*]-none}"
+    if [ ${#match[@]} -gt 0 ]; then
 	dlog "needs_initrd: yes, modules changed"
 	return 0
     fi
@@ -468,9 +470,9 @@ needs_initrd() {
 }
 
 # run depmod and rebuild initrd for kernel version $krel
-# stdin - list of changed modules ("_kernel_" for a whole kernel)
+# stdin - list of changed modules
 run_depmod_build_initrd() {
-    local krel=$1
+    local krel=$1 is_kernel=$2
     local status=0
     local system_map
 
@@ -480,7 +482,7 @@ run_depmod_build_initrd() {
 	   doit "$DEPMOD" -F "$system_map" -ae "$krel" || return 1
 	fi
     fi
-    if needs_initrd $krel; then
+    if needs_initrd $krel $is_kernel; then
 	local image x
 	for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
 	    image=$(find_usrmerge_boot "$x" "$krel")
@@ -555,7 +557,7 @@ kernel_changed() {
 	walk_kmps "$krel"
     fi
 
-    echo "_kernel_" | run_depmod_build_initrd "$krel"
+    run_depmod_build_initrd "$krel" initrd_needed </dev/null
 }
 
 add_kernel() {

--- a/weak-modules2
+++ b/weak-modules2
@@ -505,7 +505,7 @@ get_image_name() {
 # rebuild initrd for kernel version $krel
 # stdin - list of changed modules
 build_initrd() {
-    local krel=$1 is_kernel=$2
+    local krel=$1 is_kernel=$2 may_delay=$3
     local status=0 image
     local system_map
 
@@ -516,7 +516,7 @@ build_initrd() {
 	    [ -z "$image" ] || break
 	done
 	if [ -n "$image" ]; then
-	    if test -n "$INITRD_IN_POSTTRANS"; then
+	    if [[ "$may_delay" ]]; then
 		mkdir -p /run/regenerate-initrd
 		doit touch /run/regenerate-initrd/$krel
 	    else
@@ -569,11 +569,13 @@ walk_kmps() {
 
 # first arg - kernel release
 # 2nd arg: is this a base pkg (-> must rebuild initrd)?
+# 3rd arg: can the initrd build be delayed to %posttrans?
 # other args - modules to add, enables depmod incremental
 # stdin: list of module basenames to feed into build_initrd / needs_initrd
 kernel_changed() {
-    local krel=$1 is_basepkg=$2 flavor=${1##*-}
+    local krel=$1 is_basepkg=$2 may_delay=$3 flavor=${1##*-}
     local system_map=$(find_usrmerge_boot System.map "$krel")
+    shift
     shift
     shift
 
@@ -591,13 +593,13 @@ kernel_changed() {
     fi
 
     run_depmod "$krel" "$@"
-    build_initrd "$krel" $is_basepkg
+    build_initrd "$krel" "$is_basepkg" "$may_delay"
 }
 
 add_kernel() {
     local krel=$1
 
-    kernel_changed "$krel" initrd_needed
+    kernel_changed "$krel" initrd_needed "$INITRD_IN_POSTTRANS"
 }
 
 remove_kernel() {
@@ -613,11 +615,48 @@ remove_kernel() {
 
 add_kernel_modules() {
     local krel=$1
+    local initrd_needed=yes
 
     sed -rn '/\.ko(|\.xz|\.gz|\.zst)/p' >$tmpdir/kernel-modules
     sed 's:.*/::' <$tmpdir/kernel-modules >$tmpdir/kernel-basenames
 
-    kernel_changed "$krel" initrd_needed $(cat $tmpdir/kernel-modules) <$tmpdir/kernel-basenames
+    # If INITRD_IN_POSTTRANS isn't set, and a kernel base package
+    # is installed / updated together with subpackages, the base package
+    # is processed first. If a module from a subpackage is necessary
+    # in the initrd, it will be missing at that stage, and the initrd
+    # will be built without it. Therefore we need to force initrd rebuild
+    # in that case. If INITRD_IN_POSTTRANS is set, this won't happen, and
+    # we only need to force initrd creation if one of the modules of
+    # our subpkg are present in the initrd.
+    if [[ $INITRD_IN_POSTTRANS ]]; then
+	initrd_needed=
+    fi
+    # shellcheck disable=2046
+    kernel_changed "$krel" "$initrd_needed" "$INITRD_IN_POSTTRANS" \
+		   $(cat "$tmpdir/kernel-modules") \
+		   <"$tmpdir/kernel-basenames"
+}
+
+# for package deletion, there's no %posttrans, therefore delaying the
+# initrd rebuild is not generally possible. But if some other package
+# has scheduled a rebuild for the given kernel already, we can.
+# (this would happen on a KMP update, for example).
+may_delay_on_removal() {
+    local krel=$1 res="" image
+
+    if [[ $INITRD_IN_POSTTRANS ]]; then
+	if [[ -e /run/regenerate-initrd/all ]]; then
+	    res="1"
+	else
+	    image=$(get_image_name "$krel")
+
+	    if [[ -e /run/regenerate-initrd/$image-$krel ]]; then
+		res="1"
+	    fi
+	fi
+    fi
+    dlog "may_delay_on_removal => \"$res\""
+    echo "$res"
 }
 
 remove_kernel_modules() {
@@ -627,7 +666,8 @@ remove_kernel_modules() {
     sed 's:.*/::' <$tmpdir/kernel-modules >$tmpdir/kernel-basenames
 
     # FIXME: remove KMP symlinks that no longer work
-    kernel_changed "$krel" initrd_needed <$tmpdir/kernel-basenames
+    kernel_changed "$krel" "" "$(may_delay_on_removal "$krel")" \
+		   <$tmpdir/kernel-basenames
 }
 
 add_kmp() {
@@ -655,7 +695,8 @@ add_kmp() {
 	if kmp_is_present $kmp $krel; then
 	    log "Package $kmp does not need to be added to kernel $krel"
 	    run_depmod "$krel" && \
-		build_initrd "$krel" <$tmpdir/basenames-$kmp || \
+		build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
+			     <$tmpdir/basenames-$kmp || \
 		    status=1
 	    continue
 	fi
@@ -666,13 +707,14 @@ add_kmp() {
 	    if [ -z "$old_kmp" ]; then
 		log "Package $kmp added to kernel $krel"
 		run_depmod "$krel" $(cat $tmpdir/modules-$kmp) && \
-		    build_initrd "$krel" <$tmpdir/basenames-$kmp || \
+		    build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
+				 <$tmpdir/basenames-$kmp || \
 			status=1
 	    else
 		log "Package $old_kmp replaced by package $kmp in kernel $krel"
 		run_depmod "$krel" $(cat $tmpdir/modules-$kmp) && \
 		    cat $tmpdir/basenames-{$old_kmp,$kmp} \
-			| build_initrd "$krel" || \
+			| build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" || \
 			status=1
 	    fi
 	elif [[ $old_kmp ]]; then
@@ -736,7 +778,7 @@ remove_kmp() {
 		log "Package $kmp replaced by package $other_kmp in kernel $krel"
 		run_depmod "$krel" && \
 		    cat $tmpdir/basenames-{$kmp,$other_kmp} \
-			| build_initrd "$krel" || \
+			| build_initrd "$krel" "" "$(may_delay_on_removal "$krel")" || \
 			status=1
 	    else
 		log "Package $kmp removed from kernel $krel"
@@ -744,7 +786,8 @@ remove_kmp() {
 		    log "Weak-updates symlinks to no other $kmpshort package could be created"
 		fi
 		run_depmod "$krel" && \
-		    build_initrd "$krel" <$tmpdir/basenames-$kmp || \
+		    build_initrd "$krel" "" "$(may_delay_on_removal "$krel")" \
+				 <$tmpdir/basenames-$kmp || \
 			status=1
 	    fi
 	fi

--- a/weak-modules2
+++ b/weak-modules2
@@ -718,6 +718,25 @@ add_kmp() {
 	system_map=$(find_usrmerge_boot System.map "$krel")
 	[ -n "$system_map" ] || continue
 
+	# The following call to has_unresolved_symbols() would just produce
+	# a warning, in a case that shouldn't occur in a properly configured
+	# system anyway. It could be skipped with no significant feature loss.
+	# But there's a strange performance phenomenon: has_unresolved_symbols()
+	# (i.e. a full depmod run) normally takes ~10s if the module files
+	# aren't in the page cache. Follow-up depmod calls take ~2s only for
+	# zstd-compressed modules. If we skip the call below,
+	# has_unresolved_symbols() will be called later on a temporary copy of
+	# /lib/modules/$krel, where almost all files and directories are
+	# symlinks into the "real" /lib/modules/$krel (see create_temporary_modules_dir()
+	# above). In my tests, the depmod call on the temporary directory
+	# consistently took 30s! The bottom line is that doing this extra
+	# depmod call speeds up the execution of weak_modules2, although it
+	# needs 10 extra seconds in the first place.  If $WM2_DEPMOD_INC is
+	# set, this call has no effect; skip it.
+	if [[ ! $WM2_DEPMOD_INC ]] && opt_debug=1 has_unresolved_symbols "$krel" "/"; then
+	    echo "Warning: /lib/modules/$krel is inconsistent" >&2
+	    echo "Warning: weak-updates symlinks might not be created" >&2
+	fi
 	if kmp_is_present $kmp $krel; then
 	    log "Package $kmp does not need to be added to kernel $krel"
 	    run_depmod "$krel" && \
@@ -749,10 +768,6 @@ add_kmp() {
 	    log "Package $old_kmp kept in kernel $krel (not replaced by $kmp)"
 	else
 	    echo "FAILED to add $kmp in kernel $krel" >&2
-	    if [[ $opt_debug -gt 0 ]] && \
-		   has_unresolved_symbols "$krel" "/"; then
-		echo "Warning: /lib/modules/$krel is inconsistent" >&2
-	    fi
 	fi
     done
     dlog "add_kmp: status=$status"

--- a/weak-modules2
+++ b/weak-modules2
@@ -469,12 +469,8 @@ needs_initrd() {
     return 1
 }
 
-# run depmod and rebuild initrd for kernel version $krel
-# stdin - list of changed modules
-run_depmod_build_initrd() {
-    local krel=$1 is_kernel=$2
-    local status=0
-    local system_map
+run_depmod() {
+    local krel=$1
 
     if [ -d /lib/modules/$krel ]; then
 	system_map=$(find_usrmerge_boot System.map "$krel")
@@ -482,6 +478,15 @@ run_depmod_build_initrd() {
 	   doit "$DEPMOD" -F "$system_map" -ae "$krel" || return 1
 	fi
     fi
+}
+
+# rebuild initrd for kernel version $krel
+# stdin - list of changed modules
+build_initrd() {
+    local krel=$1 is_kernel=$2
+    local status=0
+    local system_map
+
     if needs_initrd $krel $is_kernel; then
 	local image x
 	for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
@@ -557,7 +562,8 @@ kernel_changed() {
 	walk_kmps "$krel"
     fi
 
-    run_depmod_build_initrd "$krel" initrd_needed </dev/null
+    run_depmod "$krel"
+    build_initrd "$krel" initrd_needed </dev/null
 }
 
 add_kernel() {
@@ -616,8 +622,9 @@ add_kmp() {
 
 	if kmp_is_present $kmp $krel; then
 	    log "Package $kmp does not need to be added to kernel $krel"
-	    run_depmod_build_initrd "$krel" <$tmpdir/basenames-$kmp || \
-		status=1
+	    run_depmod "$krel" && \
+		build_initrd "$krel" <$tmpdir/basenames-$kmp || \
+		    status=1
 	    continue
 	fi
 	local old_kmp=$(previous_version_of_kmp $kmp $krel)
@@ -626,12 +633,15 @@ add_kmp() {
 	    add_kmp_modules "$kmp" "$krel"
 	    if [ -z "$old_kmp" ]; then
 		log "Package $kmp added to kernel $krel"
-		run_depmod_build_initrd "$krel" <$tmpdir/basenames-$kmp || \
-		    status=1
+		run_depmod "$krel" && \
+		    build_initrd "$krel" <$tmpdir/basenames-$kmp || \
+			status=1
 	    else
 		log "Package $old_kmp replaced by package $kmp in kernel $krel"
-		cat $tmpdir/basenames-{$old_kmp,$kmp} \
-		| run_depmod_build_initrd "$krel" || status=1
+		run_depmod "$krel" && \
+		    cat $tmpdir/basenames-{$old_kmp,$kmp} \
+			| build_initrd "$krel" || \
+			status=1
 	    fi
 	elif [[ $old_kmp ]]; then
 	    log "Package $old_kmp kept in kernel $krel (not replaced by $kmp)"
@@ -692,15 +702,18 @@ remove_kmp() {
 	    done < $tmpdir/kmps
 	    if [ -n "$other_kmp" ]; then
 		log "Package $kmp replaced by package $other_kmp in kernel $krel"
-		cat $tmpdir/basenames-{$kmp,$other_kmp} \
-		| run_depmod_build_initrd "$krel" || status=1
+		run_depmod "$krel" && \
+		    cat $tmpdir/basenames-{$kmp,$other_kmp} \
+			| build_initrd "$krel" || \
+			status=1
 	    else
 		log "Package $kmp removed from kernel $krel"
 		if [ $other_found -eq 1 ]; then
 		    log "Weak-updates symlinks to no other $kmpshort package could be created"
 		fi
-		run_depmod_build_initrd "$krel" <$tmpdir/basenames-$kmp || \
-		    status=1
+		run_depmod "$krel" && \
+		    build_initrd "$krel" <$tmpdir/basenames-$kmp || \
+			status=1
 	    fi
 	fi
     done

--- a/weak-modules2
+++ b/weak-modules2
@@ -153,7 +153,7 @@ __kmp_is_present() {
     local module symlink
     while read module; do
 	symlink=$(symlink_to_module $module $krel)
-	[ $module -ef $symlink -o $module = "$(readlink $symlink)" ] || return 1
+	[[ $module -ef $symlink || $module = "$(readlink $symlink)" ]] || return 1
     done < $tmpdir/modules-$kmp
 
     return 0
@@ -268,13 +268,13 @@ has_unresolved_symbols() {
 
 # KMPs can only be added if none of the module basenames overlap
 basenames_are_unique() {
-    local kmp=$1 krel=$2 basedir=$3 dir
+    local kmp=$1 krel=$2 basedir=$3 dir overlap
 
     for dir in $basedir/lib/modules/$krel/{weak-updates,updates,extra}/; do
         if [ ! -d "$dir" ]; then
             continue
         fi
-	local overlap="$(comm -1 -2 $tmpdir/basenames-$kmp \
+	overlap="$(comm -1 -2 $tmpdir/basenames-$kmp \
                <(find "$dir" -not -type d -printf '%f\n' | sort -u))"
         if [ -n "$overlap" ]; then
 	    dlog "basenames_are_unique: found name overlap for $kmp in $dir: " $overlap
@@ -291,7 +291,6 @@ __can_replace_kmp() {
     local old_kmp=$1 new_kmp=$2 krel=$3
 
     local basedir=$tmpdir/$krel
-    local weak_updates=/lib/modules/$krel/weak-updates/
 
     [ -d "$basedir" ] || \
 	create_temporary_modules_dir "$krel" "$basedir"
@@ -323,8 +322,9 @@ check_kmp() {
     local kmp=$1
 
     # Make sure all modules are for the same kernel
+    # shellcheck disable=2046
     set -- $(sed -re 's:^/lib/modules/([^/]+)/.*:\1:' \
-		 $tmpdir/modules-$kmp \
+		 "$tmpdir/modules-$kmp" \
 	     | sort -u)
     if [ $# -ne 1 ]; then
 	echo "Error: package $kmp seems to contain modules for multiple" \
@@ -343,6 +343,7 @@ check_kmp() {
     fi
     sed -e 's:.*/::' $tmpdir/modules-$kmp \
 	| sort -u > $tmpdir/basenames-$kmp
+    # shellcheck disable=2046
     dlog "check_kmp: $kmp contains: " $(cat $tmpdir/basenames-$kmp)
 }
 
@@ -376,6 +377,7 @@ find_kmps() {
     | /usr/lib/rpm/rpmsort -r \
     > $tmpdir/kmps
 
+    # shellcheck disable=2046
     dlog "find_kmps: kmps found: " $(cat $tmpdir/kmps)
 }
 
@@ -401,8 +403,10 @@ __previous_version_of_kmp() {
 }
 
 previous_version_of_kmp() {
-    local old="$(__previous_version_of_kmp "$1" "$2")"
-    local res=$?
+    local old res
+
+    old="$(__previous_version_of_kmp "$1" "$2")"
+    res=$?
     dlog "previous_version_of_kmp: kmp=$1 krel=$2 => $old"
     echo "$old"
     return $res
@@ -432,7 +436,7 @@ needs_initrd() {
         return 1
     fi
 
-    if ! [ -f /etc/fstab -a ! -e /.buildenv -a -x "$DRACUT" ] ; then
+    if ! [[ -f /etc/fstab && ! -e /.buildenv && -x "$DRACUT" ]] ; then
 	echo "Please run \"$DRACUT -f /boot/initrd-$krel $krel\" as soon as your system is complete." >&2
 	return 1
     fi
@@ -531,12 +535,12 @@ build_initrd() {
 }
 
 walk_kmps() {
-    local krel=$1
-    local kmps=( $(cat $tmpdir/kmps) )
+    local krel=$1 kmp
 
+    mapfile -t kmps < "$tmpdir/kmps"
     while :; do
 	[ ${#kmps[@]} -gt 0 ] || break
-	local added='' skipped='' n kmp
+	local added='' skipped='' n kmp old_kmp
 	for ((n=0; n<${#kmps[@]}; n++)); do
 	    kmp=${kmps[n]}
 	    [ -n "$kmp" ] || continue
@@ -547,7 +551,7 @@ walk_kmps() {
 		kmps[n]=''
 		continue
 	    fi
-	    local old_kmp=$(previous_version_of_kmp $kmp $krel)
+	    old_kmp=$(previous_version_of_kmp $kmp $krel)
 	    if can_replace_kmp "$old_kmp" $kmp $krel; then
 		remove_kmp_modules "$old_kmp" "$krel"
 		add_kmp_modules "$kmp" "$krel"
@@ -563,7 +567,7 @@ walk_kmps() {
 	    dlog "walk_kmps: skipped $kmp"
 	    skipped=1
 	done
-	[ -n "$added" -a -n "$skipped" ] || break
+	[[ -n "$added" && -n "$skipped" ]] || break
     done
 }
 
@@ -673,12 +677,11 @@ remove_kernel_modules() {
 add_kmp() {
     local kmp=$1 kmpshort=${1%-*-*}
     local basename=${kmpshort%-kmp-*} flavor=${kmpshort##*-}
-    local system_map
+    local system_map dir krel status old_kmp
 
     # Find the kmp to be added as well as any previous versions
     find_kmps "$basename" "$flavor" || return 1
 
-    local dir krel status
     for dir in /lib/modules/*; do
 	krel=${dir#/lib/modules/}
         case "$krel" in
@@ -696,24 +699,26 @@ add_kmp() {
 	    log "Package $kmp does not need to be added to kernel $krel"
 	    run_depmod "$krel" && \
 		build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
-			     <$tmpdir/basenames-$kmp || \
+			     <"$tmpdir/basenames-$kmp" || \
 		    status=1
 	    continue
 	fi
-	local old_kmp=$(previous_version_of_kmp $kmp $krel)
-	if can_replace_kmp "$old_kmp" $kmp $krel; then
+	old_kmp=$(previous_version_of_kmp "$kmp" "$krel")
+	if can_replace_kmp "$old_kmp" "$kmp" "$krel"; then
 	    remove_kmp_modules "$old_kmp" "$krel"
 	    add_kmp_modules "$kmp" "$krel"
 	    if [ -z "$old_kmp" ]; then
 		log "Package $kmp added to kernel $krel"
-		run_depmod "$krel" $(cat $tmpdir/modules-$kmp) && \
+		# shellcheck disable=2046
+		run_depmod "$krel" $(cat "$tmpdir/modules-$kmp") && \
 		    build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" \
-				 <$tmpdir/basenames-$kmp || \
+				 <"$tmpdir/basenames-$kmp" || \
 			status=1
 	    else
 		log "Package $old_kmp replaced by package $kmp in kernel $krel"
-		run_depmod "$krel" $(cat $tmpdir/modules-$kmp) && \
-		    cat $tmpdir/basenames-{$old_kmp,$kmp} \
+		# shellcheck disable=2046
+		run_depmod "$krel" $(cat "$tmpdir/modules-$kmp") && \
+		    cat "$tmpdir/basenames-{$old_kmp,$kmp}" \
 			| build_initrd "$krel" "" "$INITRD_IN_POSTTRANS" || \
 			status=1
 	    fi
@@ -915,7 +920,7 @@ case "$mode" in
     if [ $# -gt 1 ]; then
         err="Too many arguments to $mode"
     fi
-    [ $# -eq 1 ] || set -- $(uname -r)
+    [ $# -eq 1 ] || set -- "$(uname -r)"
     ;;
 *)
     if [ $# -ne 1 ]; then
@@ -944,8 +949,8 @@ fi
 find_depmod
 find_lsinitrd
 
-tmpdir=$(mktemp -d /var/tmp/${0##*/}.XXXXXX)
-trap "rm -rf $tmpdir" EXIT
+tmpdir="$(mktemp -d /var/tmp/${0##*/}.XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
 
 shopt -s nullglob
 

--- a/weak-modules2
+++ b/weak-modules2
@@ -491,11 +491,22 @@ run_depmod() {
     fi
 }
 
+get_image_name() {
+    local krel=$1 x
+
+    for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
+	if [ -f /boot/"$x-$krel" ]; then
+	    echo "$x"
+	    return
+	fi
+    done
+}
+
 # rebuild initrd for kernel version $krel
 # stdin - list of changed modules
 build_initrd() {
     local krel=$1 is_kernel=$2
-    local status=0
+    local status=0 image
     local system_map
 
     if needs_initrd $krel $is_kernel; then

--- a/weak-modules2
+++ b/weak-modules2
@@ -671,12 +671,7 @@ remove_kmp() {
 	[ -n "$system_map" ] || continue
 	dlog "remove_kmp: processing $kmp for $krel"
 	if kmp_is_present $kmp $krel; then
-	    local other_found=0 inconsistent=0
-
-	    if opt_debug=1 has_unresolved_symbols "$krel" "/" \
-			>$tmpdir/unresolved-"$krel" 2>&1; then
-		inconsistent=1
-	    fi
+	    local other_found=0
 
             if [ $krel != "$(cat $tmpdir/krel-$kmp)" ]; then
                 remove_kmp_modules "$kmp" "$krel"
@@ -701,16 +696,10 @@ remove_kmp() {
 		log "Package $kmp removed from kernel $krel"
 		if [ $other_found -eq 1 ]; then
 		    log "Weak-updates symlinks to no other $kmpshort package could be created"
-		    if [ $inconsistent -eq 1 ]; then
-			echo "Warning: /lib/modules/$krel was inconsistent before removal of $kmp" >&2
-			[ -s $tmpdir/unresolved-"$krel" ] && \
-			    cat $tmpdir/unresolved-"$krel"
-		    fi
 		fi
 		run_depmod_build_initrd "$krel" <$tmpdir/basenames-$kmp || \
 		    status=1
 	    fi
-	    rm -f $tmpdir/unresolved-"$krel"
 	fi
     done
     dlog "remove_kmp: status=$status"

--- a/weak-modules2
+++ b/weak-modules2
@@ -203,8 +203,7 @@ create_temporary_modules_dir() {
     mkdir -p $opt_v $basedir$modules_dir/weak-updates
     ln -s $opt_v $modules_dir/kernel $basedir$modules_dir/kernel
 
-    eval "$(find $modules_dir -path "$modules_dir/modules.*" -prune \
-		-o -path "$modules_dir/kernel" -prune \
+    eval "$(find $modules_dir -path "$modules_dir/kernel" -prune \
 		-o -type d -printf "mkdir -p $opt_v $basedir%p\n" \
 		-o -printf "ln -s $opt_v %p $basedir%p\n"
            )"
@@ -469,14 +468,24 @@ needs_initrd() {
     return 1
 }
 
+# run depmod
+# first arg - kernel release; more args - modules to add (if any),
+# will enable depmod incremental mode
 run_depmod() {
-    local krel=$1
+    local krel=$1 status
 
-    if [ -d /lib/modules/$krel ]; then
-	system_map=$(find_usrmerge_boot System.map "$krel")
-	if [ -n "$system_map" ]; then
-	   doit "$DEPMOD" -F "$system_map" -ae "$krel" || return 1
-	fi
+    [[ -d /lib/modules/$krel ]] || return
+    system_map=$(find_usrmerge_boot System.map "$krel")
+    [[ $system_map ]] || return
+    shift
+    status=1
+    if [[ $WM2_DEPMOD_INC && $# -gt 0 ]]; then
+	doit "$DEPMOD" -F "$system_map" -ae -I "$krel" "$@"
+	status=$?
+    fi
+    if [[ $status -ne 0 ]]; then
+       # fall back to full depmod
+       doit "$DEPMOD" -F "$system_map" -ae "$krel"
     fi
 }
 
@@ -545,9 +554,12 @@ walk_kmps() {
     done
 }
 
+# first arg - kernel release
+# other args - modules to add, enables depmod incremental
 kernel_changed() {
     local krel=$1 flavor=${1##*-}
     local system_map=$(find_usrmerge_boot System.map "$krel")
+    shift
 
     if [ -z "$system_map" ]; then
 	# this kernel does not exist anymore
@@ -562,7 +574,7 @@ kernel_changed() {
 	walk_kmps "$krel"
     fi
 
-    run_depmod "$krel"
+    run_depmod "$krel" "$@"
     build_initrd "$krel" initrd_needed </dev/null
 }
 
@@ -585,9 +597,9 @@ remove_kernel() {
 
 add_kernel_modules() {
     local krel=$1
-    cat >/dev/null
 
-    kernel_changed $krel
+    sed -rn '/\.ko(|\.xz|\.gz|\.zst)/p' >$tmpdir/kernel-modules
+    kernel_changed "$krel" $(cat $tmpdir/kernel-modules)
 }
 
 remove_kernel_modules() {
@@ -595,7 +607,7 @@ remove_kernel_modules() {
     cat >/dev/null
 
     # FIXME: remove KMP symlinks that no longer work
-    kernel_changed $krel
+    kernel_changed "$krel"
 }
 
 add_kmp() {
@@ -633,12 +645,12 @@ add_kmp() {
 	    add_kmp_modules "$kmp" "$krel"
 	    if [ -z "$old_kmp" ]; then
 		log "Package $kmp added to kernel $krel"
-		run_depmod "$krel" && \
+		run_depmod "$krel" $(cat $tmpdir/modules-$kmp) && \
 		    build_initrd "$krel" <$tmpdir/basenames-$kmp || \
 			status=1
 	    else
 		log "Package $old_kmp replaced by package $kmp in kernel $krel"
-		run_depmod "$krel" && \
+		run_depmod "$krel" $(cat $tmpdir/modules-$kmp) && \
 		    cat $tmpdir/basenames-{$old_kmp,$kmp} \
 			| build_initrd "$krel" || \
 			status=1


### PR DESCRIPTION
- labsconf 2021 debugging / profiling
- weak-modules2: remove pointless debug statements in add_kmp_modules
- weak-modules2: skip "test" call to has_unresolved_symbols
- weak-modules2: try incremental depmod in has_unresolved_symbols
- weak-modules2: remove_kmp(): drop inconsistency test
- weak-modules2: sanitize "_kernel_" logic
- weak-modules2: split run_depmod() and build_initrd()
- weak-modules2: incremental depmod in run_depmod with WM2_DEPMOD_INC
- weak-modules2: use needs_initrd for kernel subpackages
- weak-modules2: factor out get_image_name()
- weak-modules2: honor INITRD_IN_POSTTRANS for kernel packages
