### PR TITLE
cert-script: Only print mokutil output in verbose mode.

### DIFF
--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -51,16 +51,19 @@ case $op in
     pre)
 	;;
     post)
+	MOK_ARGS=""
 	# Only apply CA check on the kernel package certs (bsc#1173115)
 	if [ -n "$ca_check" ] && mokutil -h | grep -q "ca-check"; then
-	    MOK_ARG="--ca-check"
-	else
-	    MOK_ARG=""
+	    MOK_ARGS="${MOK_ARGS} --ca-check"
+	fi
+	# Kernel key needs to be enrolled even if it's in the kernel keyring (bsc#1191480)
+	if [ -n "$ca_check" ] && mokutil -h | grep -q "ignore-keyring"; then
+	    MOK_ARGS="${MOK_ARGS} --ignore-keyring"
 	fi
 	# XXX: Only call mokutil if UEFI and shim are used
 	for cert in $certs; do
 	    cert="/etc/uefi/certs/${cert}.crt"
-	    run_mokutil --import "$cert" --root-pw ${MOK_ARG}
+	    run_mokutil --import "$cert" --root-pw ${MOK_ARGS}
 	    rc=$?
 	    if [ $rc != 0 ] ; then
 		script_rc=$rc


### PR DESCRIPTION
In recent bug reports the mokutil output appears in rpm output