### PR TITLE
boot-sysctl: make sure file exists

### DIFF
--- a/boot-sysctl.service
+++ b/boot-sysctl.service
@@ -5,6 +5,7 @@ Conflicts=shutdown.target
 Before=systemd-sysctl.service
 After=systemd-modules-load.service
 ConditionPathExists=!/usr/lib/modules/%v/sysctl.conf
+ConditionPathExists=/boot/sysctl.conf-%v
 RequiresMountsFor=/boot
 
 [Service]


### PR DESCRIPTION
In containers no kernel might be installed. So make sure the service
does not fail.