### PR TITLE
Make regenerate-initrd-posttrans compatible with Dracut's UEFI mode (…

### DIFF
--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -54,7 +54,7 @@ for f in "$dir"/*; do
 		echo "$0: /boot/$image does not exist, initrd won't be generated"
 		continue
 	fi
-	if ! "$DRACUT" -f "/boot/initrd-$kver" "$kver"; then
+	if ! "$DRACUT" -f --kver "$kver"; then
 		err=$?
 	fi
 done


### PR DESCRIPTION
…unified kernel image)

Right now, we blindly install Dracut's output to `/boot` regardless of what is chosen in `dracut.conf`.
Turns out, Dracut is smart enough to install into the correct location (either `boot` or the EFI partition)
depending on whether it is producing an iniutrd or a unified kernel image.
This change makes us compatible with the user setting `uefi=yes` inside `dracut.conf`,
and gives us automatic preliminary systemd-boot support (inherited from dracut)
with no changes needed in `perl-Bootloader` or anywhere else.