### PR TITLE
Avoid bashism in rpm-script (bsc#1195391)

### DIFF
--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -82,7 +82,7 @@ disarm_purge_kernels() {
 
 run_wm2() {
     [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || echo wm2 "$@" >&2
-    /bin/bash -${-/e/} $wm2 "$@"
+    /bin/bash -$- +e $wm2 "$@"
 }
 
 message_install_bl () {


### PR DESCRIPTION
The rpm-script is using a bashism here:

  bash -${-/e/}

in order to call another script via bash. the easiest way to fix that
is to use bash -$- +e. While that hides the dependency on bash,
weak-modules2 will be detected as bash script so we have it always
available.