### PR TITLE
kernel-scriptlets: don't pass flags to weak-modules2

### DIFF
--- a/kernel-scriptlets/inkmp-script
+++ b/kernel-scriptlets/inkmp-script
@@ -72,7 +72,7 @@ fi
 
 run_wm2() {
     [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || echo wm2 "$@" >&2
-    /bin/bash -${-/e/} $wm2 "$@"
+    $wm2 "$@"
 }
 
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \

--- a/kernel-scriptlets/kmp-script
+++ b/kernel-scriptlets/kmp-script
@@ -48,7 +48,7 @@ nvr="$name"-"$version"-"$release"
 
 run_wm2() {
     [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || echo wm2 "$@" >&2
-    /bin/bash -${-/e/} $wm2 "$@"
+    $wm2 "$@"
 }
 
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -82,7 +82,7 @@ disarm_purge_kernels() {
 
 run_wm2() {
     [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || echo wm2 "$@" >&2
-    /bin/bash -${-/e/} $wm2 "$@"
+    $wm2 "$@"
 }
 
 message_install_bl () {


### PR DESCRIPTION
The invocation of weak-modules2 was a bashism. We don't need
to pass any shell flags anyway. So replace it by a simple
command execution.

Alternative PR for #61.
Fixes #61.
