### PR TITLE
driver-check.sh, unblacklist: convert egrep to grep -E

### DIFF
--- a/driver-check.sh
+++ b/driver-check.sh
@@ -131,7 +131,7 @@ check_kernel_package()
 	if ! rpm -q --qf '%{description}\n' "$kernel" | grep -q '^GIT '; then
 		error "$kernel does not look like a SUSE kernel package (no commit id)"
 	fi
-	if ! rpm -q --qf '%{postin}\n' "$kernel" | egrep -Eq 'weak-modules2|kernel-scriptlets/rpm-post'; then
+	if ! rpm -q --qf '%{postin}\n' "$kernel" | grep -Eq 'weak-modules2|kernel-scriptlets/rpm-post'; then
 		error "$kernel does not look like a SUSE kernel package (wrong %post script)"
 	fi
 }
@@ -186,7 +186,7 @@ check_kmp()
 {
 	local kmp=$1 prefix prev_krel krel path found_module=false
 
-	if ! rpm -q --qf '%{postin}\n' "$kmp" | egrep -Eq 'weak-modules2|kernel-scriptlets/kmp-post'; then
+	if ! rpm -q --qf '%{postin}\n' "$kmp" | grep -Eq 'weak-modules2|kernel-scriptlets/kmp-post'; then
 		error "$kmp does not look like a SUSE kernel module package (wrong %post)"
 	fi
 	if ! rpm -q -R "$kmp" | grep -Eq "$req_re"; then

--- a/unblacklist
+++ b/unblacklist
@@ -36,11 +36,11 @@ if [ -L "$CONF" ]; then
 	exit 1
     fi
 elif [ -f "$CONF" ]; then
-    if ! egrep -q "^[ 	]*blacklist[ 	]+$MODULE" "$CONF"; then
+    if ! grep -E -q "^[ 	]*blacklist[ 	]+$MODULE" "$CONF"; then
 	# not blacklisted
 	exit 0
     fi
-    if ! egrep -q '^# __THIS FILE MAY BE MODIFIED__' "$CONF"; then
+    if ! grep -E -q '^# __THIS FILE MAY BE MODIFIED__' "$CONF"; then
 	echo "$ME: $CONF exists, cannot modify it" >&2
 	exit 1
     fi


### PR DESCRIPTION
grep 3.8 starts throwing warnings, and `egrep`/`fgrep` will be dropped long term
https://bugzilla.opensuse.org/show_bug.cgi?id=1203092
