### PR TITLE
mokutil shall only be called when efivarfs is writeable

### DIFF
--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -73,7 +73,7 @@ case $op in
 		fi
 	    done
 	else
-	    test -d /sys/firmware/efi/efivars && echo "WARNING: cannot update MOK variables since /sys/firmware/efi/efivars is not writeable" 1>&2
+	    test ! -d /sys/firmware/efi/efivars || echo "WARNING: cannot update MOK variables since /sys/firmware/efi/efivars is not writeable" 1>&2
 	fi
 	;;
     preun)

--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -60,16 +60,19 @@ case $op in
 	if [ -n "$ca_check" ] && mokutil -h | grep -q "ignore-keyring"; then
 	    MOK_ARGS="${MOK_ARGS} --ignore-keyring"
 	fi
-	# XXX: Only call mokutil if UEFI and shim are used
-	for cert in $certs; do
-	    cert="/etc/uefi/certs/${cert}.crt"
-	    run_mokutil --import "$cert" --root-pw ${MOK_ARGS}
-	    rc=$?
-	    if [ $rc != 0 ] ; then
-		script_rc=$rc
-		echo "Failed to import $cert" >&2
-	    fi
-	done
+	# XXX: Only call mokutil if UEFI and shim are used and efivarfs is writeable
+	test -w /sys/firmware/efi/efivars
+	if [ $? == 0 ] ; then
+	    for cert in $certs; do
+	        cert="/etc/uefi/certs/${cert}.crt"
+	        run_mokutil --import "$cert" --root-pw ${MOK_ARGS}
+	        rc=$?
+	        if [ $rc != 0 ] ; then
+		    script_rc=$rc
+		    echo "Failed to import $cert" >&2
+		fi
+	    done
+	fi
 	;;
     preun)
 	for cert in $certs; do

--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -64,14 +64,16 @@ case $op in
 	test -w /sys/firmware/efi/efivars
 	if [ $? == 0 ] ; then
 	    for cert in $certs; do
-	        cert="/etc/uefi/certs/${cert}.crt"
-	        run_mokutil --import "$cert" --root-pw ${MOK_ARGS}
-	        rc=$?
-	        if [ $rc != 0 ] ; then
+		cert="/etc/uefi/certs/${cert}.crt"
+		run_mokutil --import "$cert" --root-pw ${MOK_ARGS}
+		rc=$?
+		if [ $rc != 0 ] ; then
 		    script_rc=$rc
 		    echo "Failed to import $cert" >&2
 		fi
 	    done
+	else
+	    test -d /sys/firmware/efi/efivars && echo "WARNING: cannot update MOK variables since /sys/firmware/efi/efivars is not writeable" 1>&2
 	fi
 	;;
     preun)


### PR DESCRIPTION
On certain UEFI implementations, like U-Boot's, UEFI variables cannot be
changed at runtime.
As such the Linux kernel only supports a read-only efivarfs.
This patch adds a check so that an update doesn't automatically fail like
described in https://bugzilla.opensuse.org/show_bug.cgi?id=1201066