### PR TITLE
cert-script: skip cert handling if efivarfs is not writable

### DIFF
--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -39,7 +39,12 @@ if ! is_efi; then
     exit 0
 fi
 if [ ! -w /sys/firmware/efi/efivars ]; then
-    echo "$0: efivarfs is not writable, skipping certificate handling" >&2
+    mkdir -p /run/suse-kernel-rpm-scriptlets
+    if [ -n "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
+	   [ ! -e /run/suse-kernel-rpm-scriptlets/cert-warning ]; then
+	echo "$0: efivarfs is not writable, skipping certificate handling" >&2
+    fi
+    touch /run/suse-kernel-rpm-scriptlets/cert-warning
     exit 0
 fi
 

--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -38,6 +38,10 @@ if ! is_efi; then
 	echo "$0: system doesn't support UEFI, skipping certificate handling" >&2
     exit 0
 fi
+if [ ! -w /sys/firmware/efi/efivars ]; then
+    echo "$0: efivarfs is not writable, skipping certificate handling" >&2
+    exit 0
+fi
 
 run_mokutil () {
     [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || echo mokutil "$@" >&2


### PR DESCRIPTION
On certain UEFI implementations, like U-Boot's, UEFI variables cannot be
changed at runtime. As such the Linux kernel only supports a read-only efivarfs.
This patch adds a check so that an update doesn't automatically fail,
like described in boo#1201066.

Fixes #65.

