### PR TITLE
rpm-script: skip run_bootloader check (boo#1208117)

### DIFF
--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -90,20 +90,6 @@ message_install_bl () {
     echo "available bootloader for your platform (e.g. grub, lilo, zipl, ...)."
 }
 
-run_bootloader () {
-    if [ -f /etc/sysconfig/bootloader ] &&
-	[ -f /boot/grub/menu.lst -o \
-	-f /etc/lilo.conf      -o \
-	-f /etc/elilo.conf     -o \
-	-f /etc/zipl.conf      -o \
-	-f /etc/default/grub    ]
-	then
-	    return 0
-	else
-	    return 1
-    fi
-}
-
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
     echo "$op" name: "$name" version: "$version" release: "$release" \
     kernelrelease: "$kernelrelease" flavor: "$flavor" variant: "$variant" \
@@ -227,8 +213,7 @@ EOF
 		if [ "$flavor" = rt ]; then
 		    default=force-default
 		fi
-		if [ -e /boot/$initrd -o ! -e "$modules_dir" ] && \
-		    run_bootloader ; then
+		if [ -e /boot/$initrd -o ! -e "$modules_dir" ]; then
 		    [ -e /boot/$initrd ] || initrd=
 		    if [ -x /usr/lib/bootloader/bootloader_entry ]; then
 			/usr/lib/bootloader/bootloader_entry \


### PR DESCRIPTION
It would be better if `run_bootloader()` didn't make any assumption on the supported bootloaders and let /usr/lib/bootloader/bootloader_entry figure out itself what to do with the current installation. This way other boot loaders such as systemd-boot can be more easily supported in the future.