### PR TITLE
rpm-script: check for regenerate-initrd-posttrans in %posttrans

### DIFF
--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -213,6 +213,8 @@ EOF
 		if [ "$flavor" = rt ]; then
 		    default=force-default
 		fi
+		# Note: the 2nd condition is for removing the bootloader
+		# entry for an uninstalled kernel.
 		if [ -e /boot/$initrd -o ! -e "$modules_dir" ]; then
 		    [ -e /boot/$initrd ] || initrd=
 		    if [ -x /usr/lib/bootloader/bootloader_entry ]; then

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -272,6 +272,9 @@ EOF
 	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@"
 	;;
     posttrans)
+	if test -x /usr/lib/module-init-tools/regenerate-initrd-posttrans; then
+	    /bin/bash -c 'set +e; /usr/lib/module-init-tools/regenerate-initrd-posttrans' || script_rc=$?
+	fi
 	;;
     *)
 	echo Unknown scriptlet "$op" >&2


### PR DESCRIPTION
rpm-script: check for regenerate-initrd-posttrans in %posttrans (boo#1212957)

If zypper is run with INITRD_IN_POSTTRANS=1 set, no initrd will be
generated. Setting this variable globally is useful in some situations,
in particular where split kernel packages like kernel-defaukt-extra are
in use. Checking the regenerate-initrd-posttrans flag is cheap if the
flag isn't present, and will fix the issue if it is.
