### PR TITLE
regenerate-initrd-posttrans: fix typo

### DIFF
--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -50,7 +50,7 @@ for f in "$dir"/*; do
 	rm -f "$f"
 	kver=${f##*/}
 	[ -d /lib/modules/"$kver" ] || {
-	    echo $0: skippping invalid kernel version "$dir/$kver"
+	    echo $0: skipping invalid kernel version "$dir/$kver"
 	    continue
 	}
 	if ! "$DRACUT" -f --kver "$kver"; then


### PR DESCRIPTION
`s/skippping/skipping`