### PR TITLE
Revert "rpm-script: detect usrmerged automatically"

### DIFF
--- a/kernel-scriptlets/inkmp-script
+++ b/kernel-scriptlets/inkmp-script
@@ -8,6 +8,7 @@ release=""
 kernelrelease=""
 flavor=""
 variant=""
+usrmerged="0"
 image=""
 certs=""
 
@@ -40,7 +41,7 @@ while true ; do
 	    ;;
 
 	--usrmerged)
-	    # ignored for legacy compat reasons
+	    usrmerged="$2"
 	    shift
 	    ;;
 	--image)
@@ -61,7 +62,7 @@ done
 wm2=/usr/lib/module-init-tools/weak-modules2
 nvr="$name"-"$version"-"$release"
 
-if [ -L /lib ] ; then
+if [ "$usrmerged" -ne 0 ] ; then
     modules_dir=/usr/lib/modules/$kernelrelease-$flavor
     system_map=${modules_dir}/System.map
 else
@@ -77,7 +78,7 @@ run_wm2() {
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
     echo KMP "$op" name: "$name" version: "$version" release: "$release" \
     kernelrelease: "$kernelrelease" flavor: "$flavor" variant: "$variant" \
-    image: "$image" certs: "$certs" -- "$@" >&2
+    usrmerged: "$usrmerged" image: "$image" certs: "$certs" -- "$@" >&2
 
 script_rc=0
 

--- a/kernel-scriptlets/kmp-script
+++ b/kernel-scriptlets/kmp-script
@@ -7,6 +7,7 @@ version=""
 release=""
 kernelrelease=""
 flavor=""
+usrmerged=""
 
 while true ; do
     case $1 in
@@ -32,7 +33,7 @@ while true ; do
 	    shift
 	    ;;
 	--usrmerged)
-	    # ignored for legacy compat reasons
+	    usrmerged="$2"
 	    shift
 	    ;;
 
@@ -52,7 +53,7 @@ run_wm2() {
 
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
     echo KMP "$op" name: "$name" version: "$version" release: "$release" \
-    kernelrelease: "$kernelrelease" flavor: "$flavor" -- "$@" >&2
+    kernelrelease: "$kernelrelease" flavor: "$flavor" \ usrmerged: "$usrmerged" -- "$@" >&2
 
 script_rc=0
 

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -8,6 +8,7 @@ release=""
 kernelrelease=""
 flavor=""
 variant=""
+usrmerged="0"
 image=""
 certs=""
 
@@ -40,7 +41,7 @@ while true ; do
 	    ;;
 
 	--usrmerged)
-	    # ignored for legacy compat reasons
+	    usrmerged="$2"
 	    shift
 	    ;;
 	--image)
@@ -61,7 +62,7 @@ done
 wm2=/usr/lib/module-init-tools/weak-modules2
 nvr="$name"-"$version"-"$release"
 
-if [ -L /lib ] ; then
+if [ "$usrmerged" -ne 0 ] ; then
     modules_dir=/usr/lib/modules/$kernelrelease-$flavor
     system_map=${modules_dir}/System.map
 else
@@ -92,7 +93,7 @@ message_install_bl () {
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
     echo "$op" name: "$name" version: "$version" release: "$release" \
     kernelrelease: "$kernelrelease" flavor: "$flavor" variant: "$variant" \
-   image: "$image" certs: "$certs" -- "$@" >&2
+    usrmerged: "$usrmerged" image: "$image" certs: "$certs" -- "$@" >&2
 
 script_rc=0
 
@@ -173,7 +174,7 @@ EOF
 	    ln -s ${x##*/}-"$kernelrelease"-"$flavor" $x
 	done
 
-	if [ -L /lib ] ; then
+	if [ "$usrmerged" -ne 0 ] ; then
 	    # compat stuff for /boot.
 	    # if /boot and /usr are not speparate partitions we can just link
 	    # the kernel there to save space. Otherwise copy.


### PR DESCRIPTION
This reverts commit 3a6e48605b1dc4637d51c71ca788ed4fd46e5c42.

The [ -L /lib ] sounds less reliable than the kernel to telling the scripts when the modules are placed in /usr.

The kernel always knows where it placed the modules.

On the other hand, the /lib symlink only exists when a specific package is installed. This may not be the case due to package installation ordering or in special environments not directly managed by rpm.