### PR TITLE
Revert "weak-modules2: accept modules under /usr/lib/modules on stdin"

### DIFF
--- a/weak-modules2
+++ b/weak-modules2
@@ -317,7 +317,7 @@ find_kmps() {
 	    continue
 	fi
 	rpm -ql --nodigest --nosignature "$kmp" \
-	    | sed -nr 's:^(/usr)?(/lib/modules/[^/]+/.+\.ko)(\.[gx]z|\.zst)?$:\2\3:p' \
+	    | grep -Ee '^/lib/modules/[^/]+/.+\.ko(\.[gx]z|\.zst)?$' \
 	    > $tmpdir/modules-$kmp
 	if [ $? != 0 ]; then
 	    echo "WARNING: $kmp does not contain any kernel modules" >&2
@@ -602,7 +602,7 @@ remove_kmp() {
 
     # Read the list of module names from standard input
     # (This kmp may already have been removed!)
-    sed 's:^/usr::' > $tmpdir/modules-$kmp
+    cat > $tmpdir/modules-$kmp
     check_kmp "$kmp" || return 1
 
     local dir krel status


### PR DESCRIPTION
Modules under /usr not supported on SLE