### PR TITLE
Revert "weak-modules2: only use kernel version under /run/regenerate-initrd"

### DIFF
--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -47,12 +47,13 @@ for f in "$dir"/*; do
 	    "$dir/*")
 		[ -e "$f" ] || break;;
 	esac
-	rm -f "$f"
-	kver=${f##*/}
-	[ -d /lib/modules/"$kver" ] || {
-	    echo $0: skipping invalid kernel version "$dir/$kver"
-	    continue
-	}
+	rm "$f"
+	image=${f##*/}
+	kver=${image#*-}
+	if ! test -e "/boot/$image"; then
+		echo "$0: /boot/$image does not exist, initrd won't be generated"
+		continue
+	fi
 	if ! "$DRACUT" -f --kver "$kver"; then
 		err=$?
 	fi

--- a/weak-modules2
+++ b/weak-modules2
@@ -443,7 +443,7 @@ run_depmod_build_initrd() {
 	if [ -n "$image" ]; then
 	    if test -n "$INITRD_IN_POSTTRANS"; then
 		mkdir -p /run/regenerate-initrd
-		doit touch /run/regenerate-initrd/$krel
+		doit touch /run/regenerate-initrd/$image-$krel
 	    else
 		doit "$DRACUT" -f /boot/initrd-$krel $krel
 		status=$?


### PR DESCRIPTION
This reverts commit 60a2a14f978ea86938475de851292b988f8baf01.
Fixes bsc#1214877: 60a2a14 changed the API of regenerate-initrd-posttrans,
which may break some users of the API outside s-m-t.

Signed-off-by: Martin Wilck <mwilck@suse.com>
