### PR TITLE
Fix kernel test in regenerate-initrd-posttrans (bsc#1214877).

### DIFF
--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -2,9 +2,9 @@
 #
 # Packages that install kernels or kernel-modules create a flag
 #
-#   /run/regenerate-initrd/<kernel version>
+#   /run/regenerate-initrd/<kernel image>
 #
-# to have the initrd for <kernel version> generated, or
+# to have the initrd for <kernel image> generated, or
 #
 #   /run/regenerate-initrd/all
 #
@@ -48,7 +48,8 @@ for f in "$dir"/*; do
 		[ -e "$f" ] || break;;
 	esac
 	rm -f "$f"
-	kver=${f##*/}
+	image=${f##*/}
+	kver=${image#*-}
 	[ -d /lib/modules/"$kver" ] || {
 	    echo $0: skipping invalid kernel version "$dir/$kver"
 	    continue

--- a/weak-modules2
+++ b/weak-modules2
@@ -470,7 +470,7 @@ run_depmod_build_initrd() {
 	if [ -n "$image" ]; then
 	    if test -n "$INITRD_IN_POSTTRANS"; then
 		mkdir -p /run/regenerate-initrd
-		doit touch /run/regenerate-initrd/$krel
+		doit touch /run/regenerate-initrd/$image-$krel
 	    else
 		doit "$DRACUT" -f /boot/initrd-$krel $krel
 		status=$?


### PR DESCRIPTION
commit 60a2a14f978e ("weak-modules2: only use kernel version under /run/regenerate-initrd") changes the API of regenerate-initrd-posttrans to only take the kernel version, not the image name.

It also checks that the module directory exists, not the kernel image.

This is both broken.

While the image is removed with the kernel the module directory may contain KMPs built against this kernel version and remain.

Anyway, at least revert the API change, there seem to be some users outside of suse-module-tools.

The problem with the remaining kernel module directory should be resolved by moving out-of-tree KMPs outside of the kernel module directory.

Fixes: 60a2a14f978e ("weak-modules2: only use kernel version under /run/regenerate-initrd")