### PR TITLE
support old-style markers under /run/regenerate-initrd

### DIFF
--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -49,6 +49,11 @@ for f in "$dir"/*; do
 	esac
 	rm -f "$f"
 	kver=${f##*/}
+	case "$kver" in
+	    vmlinuz-*|image-*|vmlinux-*|linux-*|bzImage-*|uImage-*|Image-*|zImage-*)
+		kver=${kver#*-}
+		;;
+	esac
 	[ -d /lib/modules/"$kver" ] || {
 	    echo $0: skipping invalid kernel version "$dir/$kver"
 	    continue


### PR DESCRIPTION
With a235a6e ("weak-modules2: only use kernel version under /run/regenerate-initrd")
we changed the API for programs for creating markers under
/run/regenerate-initrd. While the main user of this API is weak-modules2,
there may be external tools relying on the old behavior. Make sure
the old style, where the name of the kernel image was as marker.

Fixes: bsc#1214877

Signed-off-by: Martin Wilck <mwilck@suse.com>
