### PR TITLE
modprobe.d: Blacklist cls_tcindex module (bsc#1210335)

### DIFF
--- a/modprobe.conf/common/50-blacklist-netcls.conf
+++ b/modprobe.conf/common/50-blacklist-netcls.conf
@@ -1,0 +1,2 @@
+# Module is affected by bsc#1210335 (CVE-2023-1829), prevent loading it unwittingly
+blacklist cls_tcindex


### PR DESCRIPTION
This should go into SLE15-SP5, SLE15-SP4 and SLE15-SP3-LTSS, SLE15-SP2-LTSS.
Not sure what is the way to submit here, so starting with the first one.