### PR TITLE
Drop support for INITRD_MODULES (jsc#PED-1915)

### DIFF
--- a/get_dracut_drivers
+++ b/get_dracut_drivers
@@ -1,0 +1,45 @@
+#! /bin/bash
+# This code reads a list of modules from stdin, and takes the
+# content of the dracut configuration files as argv[1].
+# It evaluates the dracut configuration to set the module-related
+# configuration variables add_drivers etc.
+# It appends the gathered module names to the input, and
+# filters the result using the regex from the omit_drivers variable.
+# The code is meant to be executed with decreased privileges,
+# in order to avoid sourcing arbitrary scripts as root.
+
+[[ "${WM2_VERBOSE:-0}" -le 2 ]] || set -x
+
+ME=${0##*/}
+add_drivers=""
+force_drivers=""
+omit_drivers=""
+drivers=""
+
+eval "$1" ||
+    echo "$0: error evaluating dracut configuration" >&2
+
+# sanitize omit_drivers; code similar to dracut.sh 059
+# filter out empty lines; also handle the case where omit_drivers is empty
+omit_drivers_corrected="^[[:space:]]*$"
+for d in $omit_drivers; do
+	[[ " $drivers $add_drivers " == *\ $d\ * ]] && continue
+	[[ " $drivers $force_drivers " == *\ $d\ * ]] && continue
+	omit_drivers_corrected+="|$d"
+done
+
+if [[ "${WM2_VERBOSE:-0}" -gt 0 ]]; then
+    echo "$ME: drivers='$drivers'" >&2
+    echo "$ME: add_drivers='$add_drivers'" >&2
+    echo "$ME: force_drivers='$force_drivers'" >&2
+    echo "$ME: omit_drivers='$omit_drivers'" >&2
+    echo "$ME: omit_drivers_corrected='$omit_drivers_corrected'" >&2
+fi
+
+# The sed command below converts space-separated lists to newline-separated
+{
+    cat
+    echo $drivers $add_drivers $force_drivers
+} |
+    sed -E 's/[[:space:]]+/\n/g;s/\n*$//' |
+    grep -Ev "$omit_drivers_corrected"

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -112,7 +112,7 @@ install -pm 644 "depmod-00-system.conf" "%{buildroot}%{depmod_dir}/00-system.con
 # "/usr/lib/module-init-tools" name hardcoded in other packages
 install -d -m 755 "%{buildroot}/usr/lib/module-init-tools"
 install -pm 755 -t "%{buildroot}/usr/lib/module-init-tools/" \
-	weak-modules2 driver-check.sh unblacklist lsinitrd-quick
+	weak-modules2 driver-check.sh unblacklist lsinitrd-quick get_dracut_drivers
 install -pm 755 "regenerate-initrd-posttrans" "%{buildroot}/usr/lib/module-init-tools/"
 install -d -m 755 "%{buildroot}/usr/lib/module-init-tools/kernel-scriptlets"
 install -pm 755 "kernel-scriptlets/cert-script" "%{buildroot}/usr/lib/module-init-tools/kernel-scriptlets"
@@ -226,6 +226,7 @@ exit 0
 /usr/lib/module-init-tools/lsinitrd-quick
 /usr/lib/module-init-tools/unblacklist
 /usr/lib/module-init-tools/weak-modules2
+/usr/lib/module-init-tools/get_dracut_drivers
 %{_unitdir}/*.service
 %{_unitdir}/systemd-sysctl.service.d
 %{_modulesloaddir}

--- a/weak-modules2
+++ b/weak-modules2
@@ -390,10 +390,70 @@ previous_version_of_kmp() {
     return $res
 }
 
-get_initrd_basenames() {
-    $LSINITRD /boot/initrd-$1 | \
-	sed -rn 's:.*\<usr/lib/modules/.*/::p' | \
+# Create list of dracut configuration files to read, taking into
+# account priorities of the user and built-in configuration.
+# Copied from dracut.sh as of dracut 059 (GPL-2.0-or-later)
+dropindirs_sort() {
+    local suffix=$1
+    shift
+    local -a files
+    local f d
+
+    for d in "$@"; do
+        for i in "$d/"*"$suffix"; do
+            if [[ -e $i ]]; then
+                printf "%s\n" "${i##*/}"
+            fi
+        done
+    done | sort -Vu | {
+        readarray -t files
+
+        for f in "${files[@]}"; do
+            for d in "$@"; do
+                if [[ -e "$d/$f" ]]; then
+                    printf "%s\n" "$d/$f"
+                    continue 2
+                fi
+            done
+        done
+    }
+}
+
+get_current_basenames() {
+    $LSINITRD /boot/initrd-$1 |
+	sed -rn 's:.*\<usr/lib/modules/.*/::p' |
 	strip_mod_extensions
+}
+
+DRACUT_CONFFILE=/etc/dracut.conf
+DRACUT_CONFDIR=/etc/dracut.conf.d
+DRACUT_BUILTIN_CONFDIR=/usr/lib/dracut/dracut.conf.d
+GET_DRACUT_DRIVERS=/usr/lib/module-init-tools/get_dracut_drivers
+
+get_initrd_basenames() {
+    local setpriv=$(command -v setpriv)
+    local conf= cf
+
+    [[ -x "$GET_DRACUT_DRIVERS" && "$setpriv" ]] || {
+	echo "$0: unable to parse dracut configuration, skipping it" >&2
+	get_current_basenames "$1"
+	return
+    }
+
+    [[ ! -f "$DRACUT_CONFFILE" ]] ||
+	conf="$(cat "$DRACUT_CONFFILE")"
+
+    # Assemble the content of the dracut configuration files.
+    # Make sure to put a newline between subsequent conf file contents.
+    for cf in $(dropindirs_sort .conf "$DRACUT_CONFDIR" "$DRACUT_BUILTIN_CONFDIR"); do
+	conf="$conf
+$(cat "$cf")"
+    done
+
+    # run get_dracut_drivers with reduced privileges
+    get_current_basenames "$1" |
+	"$setpriv" --reuid=nobody --regid=nobody --clear-groups --inh-caps=-all \
+		   "$GET_DRACUT_DRIVERS" "$conf"
 }
 
 # test if rebuilding initrd is needed for $krel.

--- a/weak-modules2
+++ b/weak-modules2
@@ -394,10 +394,6 @@ get_initrd_basenames() {
     $LSINITRD /boot/initrd-$1 | \
 	sed -rn 's:.*\<usr/lib/modules/.*/::p' | \
 	strip_mod_extensions
-
-    INITRD_MODULES=
-    . /etc/sysconfig/kernel &>/dev/null
-    printf '%s\n' $INITRD_MODULES
 }
 
 # test if rebuilding initrd is needed for $krel.


### PR DESCRIPTION
- weak-modules2: ignore INITRD_MODULES (jsc#PED-1915)
- weak-modules2: obtain list of initrd modules from dracut (jsc#PED-1915)
