### PR TITLE
modprobe.d: Blacklist cls_tcindex module (bsc#1210335)

### DIFF
--- a/modprobe.conf/modprobe.conf.common
+++ b/modprobe.conf/modprobe.conf.common
@@ -100,4 +100,6 @@ softdep bridge post: br_netfilter
 # SUSE INITRD: csiostor REQUIRES cxgb4
 softdep csiostor pre: cxgb4
 
+# Module is affected by bsc#1210335 (CVE-2023-1829), prevent loading it unwittingly
+blacklist cls_tcindex
 # end of common part for modprobe.conf


### PR DESCRIPTION
This is addition to #92 since 4.12-based kernels are affected too.