### PR TITLE
modprobe.d: Blacklist cls_tcindex module (bsc#1210335)

### DIFF
--- a/modprobe.conf/modprobe.conf.common
+++ b/modprobe.conf/modprobe.conf.common
@@ -95,4 +95,6 @@ softdep uas pre: usb_storage
 # SUSE INITRD: csiostor REQUIRES cxgb4
 softdep csiostor pre: cxgb4
 
+# Module is affected by bsc#1210335 (CVE-2023-1829), prevent loading it unwittingly
+blacklist cls_tcindex
 # end of common part for modprobe.conf


### PR DESCRIPTION
(cherry picked from commit ee0d691297743f64d3f2e305e51ce2d2c53068bf)

See also #94.