### PR TITLE
Add more modules to file system blacklist (jsc#PED-6167)

### DIFF
--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -28,7 +28,7 @@
 %global systemd_units %{?with_boot_sysctl:boot-sysctl.service} %{?with_kernel_sysctl:kernel-sysctl.service}
 
 # List of legacy file systems to be blacklisted by default
-%global fs_blacklist adfs affs bfs befs cramfs efs erofs exofs freevxfs hfs hpfs jfs minix nilfs2 ntfs omfs qnx4 qnx6 sysv ufs
+%global fs_blacklist adfs affs bfs befs cramfs efs erofs exofs f2fs freevxfs hfs hfsplus hpfs jffs2 jfs kafs minix nilfs2 ntfs ntfs3 omfs orangefs pstore qnx4 qnx6 romfs sysv ufs zonefs
 
 # List of all files installed under modprobe.d
 # Note: this list contains files installed by previous versions, like 00-system-937216.conf!


### PR DESCRIPTION
Added: f2fs, hfsplus, jfss2, kafs, ntfs3, orangefs, pstore, romfs, zonefs.