### PR TITLE
Include unblacklist in initramfs (bsc#1224320)

### DIFF
--- a/10-unblacklist.conf
+++ b/10-unblacklist.conf
@@ -1,0 +1,3 @@
+# We ship modprobe.d files that call unblacklist.
+# It's a noop in the initramfs, but it needs to exist.
+install_items+=" /usr/lib/module-init-tools/unblacklist "

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -20,6 +20,7 @@
 # This assumes post-usr-merge (20210527) for Tumbleweed
 %global modprobe_dir /usr/lib/modprobe.d
 %global depmod_dir /usr/lib/depmod.d
+%global dracutlibdir %{_prefix}/lib/dracut
 %global with_kernel_sysctl 1
 # boot_sysctl may be dropped on TW when we can assume that nobody keeps
 # kernel packages around that store sysctl files under /boot
@@ -126,6 +127,8 @@ for i in "pre" "preun" "post" "posttrans" "postun" ; do
     ln -s rpm-script %{buildroot}/usr/lib/module-init-tools/kernel-scriptlets/rpm-$i
 done
 
+install -d -m 755 %{buildroot}%{dracutlibdir}/dracut.conf.d
+install -pm 644 10-unblacklist.conf %{buildroot}%{dracutlibdir}/dracut.conf.d
 install -d -m 755 "%{buildroot}%{_prefix}/bin"
 
 # systemd service(s) to load kernel-specific sysctl settings
@@ -232,6 +235,8 @@ exit 0
 %{_unitdir}/systemd-sysctl.service.d
 %{_modulesloaddir}
 %{_udevrulesdir}
+%dir %{dracutlibdir}
+%{dracutlibdir}/dracut.conf.d
 %ifarch ppc64 ppc64le
 /usr/lib/systemd/system-generators
 %endif

--- a/unblacklist
+++ b/unblacklist
@@ -1,13 +1,19 @@
 #! /bin/sh
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
+
+ME="${0##*/}"
+if [ -e /etc/initrd-release ]; then
+    [ "$RD_DEBUG" != "yes" ] || \
+	echo "$ME: called in initramfs for \"$@\" - ignoring" >&2
+    exit 0
+fi
 
 # Never unblacklist non-interactively
 if ! tty -s <&0; then
     exit 0
 fi
 
-ME=$(basename "$0")
 if [ $UID -ne 0 ]; then
     echo "$ME: you must be root to run this program" >&2
     exit 1


### PR DESCRIPTION
Our modprobe.d files call /usr/lib/module-init-tools/unblacklist,
causing an error message if modprobe is called on one of the blacklisted
modules. Make sure unblacklist is included in the initrd, and is a no-op.

Signed-off-by: Martin Wilck <mwilck@suse.com>
