### PR TITLE
shellcheck fixes

### DIFF
--- a/kernel-scriptlets/cert-script
+++ b/kernel-scriptlets/cert-script
@@ -22,6 +22,8 @@ while true ; do
 done
 
 is_efi () {
+    # All shells supported as /bin/sh under SUSE support "local"
+    # shellcheck disable=SC3043
     local msg rc=0
 
 # The below statement fails if mokutil isn't installed or UEFI is unsupported.
@@ -72,6 +74,8 @@ case $op in
 	# XXX: Only call mokutil if UEFI and shim are used
 	for cert in $certs; do
 	    cert="/etc/uefi/certs/${cert}.crt"
+	    # Word splitting is intended here
+	    # shellcheck disable=SC2086
 	    run_mokutil --import "$cert" --root-pw ${MOK_ARGS}
 	    rc=$?
 	    if [ $rc != 0 ] ; then

--- a/kernel-scriptlets/inkmp-script
+++ b/kernel-scriptlets/inkmp-script
@@ -61,9 +61,6 @@ done
 wm2=/usr/lib/module-init-tools/weak-modules2
 nvr="$name"-"$version"-"$release"
 
-modules_dir=/usr/lib/modules/$kernelrelease-$flavor
-system_map=${modules_dir}/System.map
-
 run_wm2() {
     [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || echo wm2 "$@" >&2
     $wm2 "$@"
@@ -81,7 +78,7 @@ case $op in
 	;;
     post)
 	if [ -x "$wm2" ]; then
-	    rpm -ql "$nvr" | INITRD_IN_POSTTRANS=1 run_wm2 --add-kernel-modules $kernelrelease-$flavor || script_rc=$?
+	    rpm -ql "$nvr" | INITRD_IN_POSTTRANS=1 run_wm2 --add-kernel-modules "$kernelrelease-$flavor" || script_rc=$?
 	fi
 	;;
     preun)
@@ -98,7 +95,7 @@ case $op in
 	# This is similar to the check for $system_map in rpm-script.
 	for __i in "${!modules[@]}"; do
 	    if [[ -e "${modules[$__i]}" ]]; then
-		unset -v modules["$__i"]
+		unset -v 'modules["$__i"]'
 	    fi
 	done
 	if [[ "${#modules[@]}" == 0 ]]; then
@@ -106,7 +103,7 @@ case $op in
 	    exit 0
 	fi
 	if [ -x "$wm2" ]; then
-	    printf '%s\n' "${modules[@]}" | run_wm2 --remove-kernel-modules $kernelrelease-$flavor || script_rc=$?
+	    printf '%s\n' "${modules[@]}" | run_wm2 --remove-kernel-modules "$kernelrelease-$flavor" || script_rc=$?
 	fi
 	;;
     posttrans)

--- a/kernel-scriptlets/kmp-script
+++ b/kernel-scriptlets/kmp-script
@@ -61,14 +61,14 @@ case $op in
 	;;
     post)
 	if [ -x $wm2 ]; then
-	    INITRD_IN_POSTTRANS=1 run_wm2 --add-kmp $nvr || script_rc=$?
+	    INITRD_IN_POSTTRANS=1 run_wm2 --add-kmp "$nvr" || script_rc=$?
 	fi
 	;;
     preun)
 	rpm -ql "$nvr" | sed -n '/\.ko\(\.xz\|\.gz\|\.zst\)\?$/p' > "/var/run/rpm-$nvr-modules" || script_rc=$?
 	;;
     postun)
-	modules=( $(cat "/var/run/rpm-$nvr-modules") )
+	mapfile -t modules < "/var/run/rpm-$nvr-modules"
 	rm -f "/var/run/rpm-$nvr-modules"
 	if [ ${#modules[*]} = 0 ]; then
 	    echo "WARNING: $nvr does not contain any kernel modules" >&2

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -198,35 +198,22 @@ copy_or_link_legacy_files() {
 	ln -s ".vmlinuz-$kernelrelease-$flavor.hmac" /boot/.vmlinuz.hmac
 }
 
-[ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
-    echo "$op" name: "$name" version: "$version" release: "$release" \
-    kernelrelease: "$kernelrelease" flavor: "$flavor" variant: "$variant" \
-    image: "$image" certs: "$certs" -- "$@" >&2
-
-script_rc=0
-
-case $op in
-    pre)
-	[ -n "$is_sdbootutil" ] || check_space_in_boot
-
-	# On AArch64 we switched from 64k PAGE_SIZE to 4k PAGE_SIZE. Unfortunately
-	# btrfs can only use file systems created with the same PAGE_SIZE. So we
-	# check if the user has any btrfs file systems mounted and refuse to install
-	# in that case.
-	if [ $( uname -m ) = aarch64 -a \
-	    "$( zgrep CONFIG_ARM64_64K_PAGES=y /proc/config.gz )" -a \
-	    "$flavor" = default ]; then
-	    if [ "$FORCE_4K" = 1 ]; then
-		# The user knows what he's doing, let him be.
-		exit 0
-	    fi
-
-	    if [ "$YAST_IS_RUNNING" = "instsys" ]; then
-		# We're probably test installing the kernel, that should succeed
-		exit 0
-	    fi
-
-	    cat >&2 <<-EOF
+check_arm_pagesize() {
+    # On AArch64 we switched from 64k PAGE_SIZE to 4k PAGE_SIZE. Unfortunately
+    # btrfs can only use file systems created with the same PAGE_SIZE. So we
+    # check if the user has any btrfs file systems mounted and refuse to install
+    # in that case.
+    if [ "$flavor" = default ] && [ "$( uname -m )" = aarch64 ] && \
+	   zgrep -q CONFIG_ARM64_64K_PAGES=y /proc/config.gz; then
+	if [ "$FORCE_4K" = 1 ]; then
+	    # The user knows what he's doing, let him be.
+	    return
+	fi
+	if [ "$YAST_IS_RUNNING" = "instsys" ]; then
+	    # We're probably test installing the kernel, that should succeed
+	    return
+	fi
+	cat >&2 <<-EOF
 You are running on a 64kb PAGE_SIZE kernel. The default kernel
 switched to 4kb PAGE_SIZE which will prevent it from mounting btrfs
 or the swap partition.
@@ -245,9 +232,21 @@ You will then be on the 64kb PAGE_SIZE kernel and can update your
 system normally.
 EOF
 
-	    script_rc=1
-	fi
+	script_rc=1
+    fi
+}
 
+[ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
+    echo "$op" name: "$name" version: "$version" release: "$release" \
+    kernelrelease: "$kernelrelease" flavor: "$flavor" variant: "$variant" \
+    image: "$image" certs: "$certs" -- "$@" >&2
+
+script_rc=0
+
+case $op in
+    pre)
+	[ -n "$is_sdbootutil" ] || check_space_in_boot
+	check_arm_pagesize
 	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@" || script_rc=$?
 	;;
     post)

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -59,7 +59,6 @@ while true ; do
 done
 
 wm2=/usr/lib/module-init-tools/weak-modules2
-nvr="$name"-"$version"-"$release"
 
 modules_dir=/usr/lib/modules/$kernelrelease-$flavor
 system_map=${modules_dir}/System.map
@@ -120,16 +119,16 @@ update_bootloader_entry() {
 	    fi
 	    # Note: the 2nd condition is for removing the bootloader
 	    # entry for an uninstalled kernel.
-	    if [ -e /boot/$initrd -o ! -e "$modules_dir" ]; then
-		[ -e /boot/$initrd ] || initrd=
+	    if [ -e "/boot/$initrd" ] || [ ! -e "$modules_dir" ]; then
+		[ -e "/boot/$initrd" ] || initrd=
 		if [ -x /usr/lib/bootloader/bootloader_entry ]; then
 		    /usr/lib/bootloader/bootloader_entry \
 			add \
 			"$flavor" \
 			"$kernelrelease"-"$flavor" \
 			"$image"-"$kernelrelease"-"$flavor" \
-			$initrd \
-			$default || script_rc=$?
+			"$initrd" \
+			"$default" || script_rc=$?
 		else
 		    message_install_bl
 		fi
@@ -160,7 +159,7 @@ check_space_in_boot() {
 	    echo "Free diskspace below /boot: $mydf blocks"
 	    # echo "512 byte blocks: $(( 2 * 1024 * 20 ))"
 	    if test "$mydf" -lt  "40960" ; then
-		echo "make room for new kernel '"$flavor"' because there are less than 20MB available."
+		echo "make room for new kernel '$flavor' because there are less than 20MB available."
 		# disabled because it breaks patch rpms
 		#rm -fv /boot/"$image"-*-"$flavor"
 		rm -fv /boot/initrd-*-"$flavor"
@@ -182,10 +181,10 @@ copy_or_link_legacy_files() {
     fi
 
     for x in "$image" sysctl.conf System.map config; do
-	if [ "$separate_boot" = 1 ] || [ ! -e /boot/$x-"$kernelrelease"-"$flavor" ]; then
-	    $copy_or_link .."$modules_dir"/$x /boot/$x-"$kernelrelease"-"$flavor" || script_rc=$?
-	    if [ -e "$modules_dir"/.$x.hmac ]; then
-		$copy_or_link .."$modules_dir"/.$x.hmac /boot/.$x-"$kernelrelease"-"$flavor".hmac || script_rc=$?
+	if [ "$separate_boot" = 1 ] || [ ! -e "/boot/$x-$kernelrelease-$flavor" ]; then
+	    $copy_or_link "..$modules_dir/$x" "/boot/$x-$kernelrelease-$flavor" || script_rc=$?
+	    if [ -e "$modules_dir/.$x.hmac" ]; then
+		$copy_or_link "..$modules_dir/.$x.hmac" "/boot/.$x-$kernelrelease-$flavor".hmac || script_rc=$?
 	    fi
 	fi
     done

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -231,6 +231,13 @@ EOF
     script_rc=1
 }
 
+run_cert_script() {
+    [ -z "$certs" ] || \
+	"/usr/lib/module-init-tools/kernel-scriptlets/cert-$op" \
+	    --ca-check 1 --certs "$certs" "$@" || \
+	script_rc=$?
+}
+
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \
     echo "$op" name: "$name" version: "$version" release: "$release" \
     kernelrelease: "$kernelrelease" flavor: "$flavor" variant: "$variant" \
@@ -242,7 +249,7 @@ case $op in
     pre)
 	[ -n "$is_sdbootutil" ] || check_space_in_boot
 	check_arm_pagesize
-	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@" || script_rc=$?
+	run_cert_script "$@"
 	;;
     post)
 	# Flag to trigger /etc/init.d/purge-kernels on next reboot (fate#312018)
@@ -263,13 +270,13 @@ case $op in
 	fi
 
 	[ "$INITRD_IN_POSTTRANS" ] || update_bootloader_entry
-	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@" || script_rc=$?
+	run_cert_script "$@"
 	;;
     preun)
 	[ ! -L /boot/.vmlinuz.hmac ] ||
 	    [ "$(readlink /boot/.vmlinuz.hmac)" != ".vmlinuz-$kernelrelease-$flavor.hmac" ] ||
 	    rm -f /boot/.vmlinuz.hmac
-	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@" || script_rc=$?
+	run_cert_script "$@"
 	;;
     postun)
 	# If a kernel package is removed before the next reboot, we assume that the
@@ -308,7 +315,7 @@ case $op in
 	    fi
 	fi
 
-	[ -z "$certs" ] || /usr/lib/module-init-tools/kernel-scriptlets/cert-$op --ca-check 1 --certs "$certs" "$@"
+	run_cert_script "$@"
 	;;
     posttrans)
 	if [ -x /usr/lib/module-init-tools/regenerate-initrd-posttrans ]; then

--- a/kernel-scriptlets/rpm-script
+++ b/kernel-scriptlets/rpm-script
@@ -203,17 +203,14 @@ check_arm_pagesize() {
     # btrfs can only use file systems created with the same PAGE_SIZE. So we
     # check if the user has any btrfs file systems mounted and refuse to install
     # in that case.
-    if [ "$flavor" = default ] && [ "$( uname -m )" = aarch64 ] && \
-	   zgrep -q CONFIG_ARM64_64K_PAGES=y /proc/config.gz; then
-	if [ "$FORCE_4K" = 1 ]; then
-	    # The user knows what he's doing, let him be.
-	    return
-	fi
-	if [ "$YAST_IS_RUNNING" = "instsys" ]; then
-	    # We're probably test installing the kernel, that should succeed
-	    return
-	fi
-	cat >&2 <<-EOF
+    # FORCE_4K: The user knows what he's doing, let him be.
+    # YAST_IS_RUNNING: We're probably test installing the kernel, that should succeed
+    if [ "$flavor" != default ] || [ "$( uname -m )" != aarch64 ] || \
+	   [ "$FORCE_4K" = 1 ] || [ "$YAST_IS_RUNNING" = instsys ] || \
+	   ! zgrep -q CONFIG_ARM64_64K_PAGES /proc/config.gz; then
+	return
+    fi
+    cat >&2 <<-EOF
 You are running on a 64kb PAGE_SIZE kernel. The default kernel
 switched to 4kb PAGE_SIZE which will prevent it from mounting btrfs
 or the swap partition.
@@ -231,9 +228,7 @@ To stay with a 64kb PAGE_SIZE kernel, please follow these steps:
 You will then be on the 64kb PAGE_SIZE kernel and can update your
 system normally.
 EOF
-
-	script_rc=1
-    fi
+    script_rc=1
 }
 
 [ -z "$KERNEL_PACKAGE_SCRIPT_DEBUG" ] || \

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -60,6 +60,8 @@ Provides:       udev-extra-rules = 0.3.0
 Obsoletes:      udev-extra-rules < 0.3.0
 Provides:       system-tuning-common-SUSE = 0.3.0
 Obsoletes:      system-tuning-common-SUSE < 0.3.0
+Provides:       sdbootutil-rpm-scriptlets = 2.0
+Obsoletes:      sdbootutil-rpm-scriptlets < 2.0
 # Use weak dependencies for dracut and kmod in order to
 # keep Ring0 lean. In normal deployments, these packages
 # will be available anyway.

--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -60,8 +60,6 @@ Provides:       udev-extra-rules = 0.3.0
 Obsoletes:      udev-extra-rules < 0.3.0
 Provides:       system-tuning-common-SUSE = 0.3.0
 Obsoletes:      system-tuning-common-SUSE < 0.3.0
-Provides:       sdbootutil-rpm-scriptlets = 2.0
-Obsoletes:      sdbootutil-rpm-scriptlets < 2.0
 # Use weak dependencies for dracut and kmod in order to
 # keep Ring0 lean. In normal deployments, these packages
 # will be available anyway.


### PR DESCRIPTION
With this PR, the kernel scriptlets pass shellcheck

It contains also a few other fixes and minor code reordering.
No change of functionality.

- **rpm-script: fix minor issues reported by shellcheck**
- **rpm-script: move arm64 page-size check to separate function**
- **rpm_script: further simplify check_arm_pagesize()**
- **rpm-script: move cert-script invocation to a shell function**
- **inkmp-script: fix warnings reported by shellcheck**
- **kmp-script: fix warnings reported by shellcheck**
- **cert-script: annotate some shellcheck warnings**
