### PR TITLE
Requires sdbootutil if already installed

### DIFF
--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -52,6 +52,7 @@ Requires:       /usr/bin/sed
 Requires:       coreutils
 Requires:       findutils
 Requires:       systemd-rpm-macros
+Requires:       (sdbootutil if sdbootutil)
 Requires:       rpm
 Requires(post): /usr/bin/grep
 Requires(post): /usr/bin/sed
@@ -69,6 +70,8 @@ Recommends:     kmod
 Conflicts:      dracut < 49.1
 # TW: conflict with pre-usrmerge
 Conflicts:      filesystem < 16
+# Adds an ordering edge (from @mls)
+Suggests:       sdbootutil
 
 %description
 This package contains helper scripts for KMP installation and


### PR DESCRIPTION
If sdbootutil is used in the scriptlets, we should require it.  This can fix installation ordering issues like bsc#1228759 or bsc#1228659.