### PR TITLE
Fix get_current_initrd parser

### DIFF
--- a/weak-modules2
+++ b/weak-modules2
@@ -450,13 +450,12 @@ dropindirs_sort() {
 
 get_current_initrd() {
     local krel=$1
-    local initrd
+    local initrd="/boot/initrd-$krel"
     if [ -n "$SDBOOTUTIL" ]; then
 	if [ -z "$TRANSACTIONAL_UPDATE" ] && [ -s '/etc/kernel/entry-token' ]; then
-	    read -r initrd <<<"$(sdbootutil --entry-keys=initrd show-entry $krel)"
+	    read -r _ initrd <<<"$(sdbootutil --entry-keys=initrd show-entry $krel)"
+	    initrd="/boot/efi$initrd"
 	fi
-    else
-	initrd="/boot/initrd-$krel"
     fi
     echo "$initrd"
 }


### PR DESCRIPTION
`show-entry` return the key and the value as two different elements. This patch fix how to recover only the value part (the actual path of the initrd file)

Fix openSUSE/sdbootutil#122