### PR TITLE
mkosi-initrd: build initrds directly to /boot

### DIFF
--- a/dracut-posttrans
+++ b/dracut-posttrans
@@ -19,7 +19,3 @@ initrd_regenerate() {
 initrd_regenerate_all() {
 	"$DRACUT" -f --regenerate-all
 }
-
-initrd_cleanup() {
-	:
-}

--- a/mkosi-initrd-posttrans
+++ b/mkosi-initrd-posttrans
@@ -7,13 +7,6 @@ if [ ! -x "$MKOSI_INITRD" ]; then
 	exit 0
 fi
 
-# FIXME: mkosi-initrd fails to cp files directly to /boot
-MKOSI_INITRD_STAGING_DIR="$(mktemp -p /var/tmp/ -d -t mkosi-initrd-stagingXXXXXXXX)"
-if [ ! -d "$MKOSI_INITRD_STAGING_DIR" ]; then
-	echo "${0##*/}: failed to create mkosi-initrd staging directory." >&2
-	exit 1
-fi
-
 initrd_warn_chroot_build() {
 	# FIXME: mkosi-initrd does not provide anything like --regenerate-all yet
 	echo "Please regenerate all the initrds with \"$MKOSI_INITRD\" as soon as your system is complete." >&2
@@ -21,17 +14,7 @@ initrd_warn_chroot_build() {
 
 initrd_regenerate() {
 	local kver="$1"
-	local res
-
-	"$MKOSI_INITRD" --kernel-version "$kver" -O "$MKOSI_INITRD_STAGING_DIR" -o "initrd-$kver"
-	res=$?
-	[ $res -ne 0 ] && return $res
-
-	chmod 600 "$MKOSI_INITRD_STAGING_DIR/initrd-$kver"
-	res=$?
-	[ $res -ne 0 ] && return $res
-
-	cp --reflink=auto "$MKOSI_INITRD_STAGING_DIR/initrd-$kver" "/boot/initrd-$kver"
+	"$MKOSI_INITRD" --kernel-version "$kver" -O "/boot" -o "initrd-$kver"
 }
 
 initrd_regenerate_all() {
@@ -41,18 +24,6 @@ initrd_regenerate_all() {
 	for d in /lib/modules/*; do
 		[ -d "$d" ] || continue
 		kver=${d##*/}
-		# The staging dir will contain: initrd-<kver> -> initrd-<kver>.cpio.zst
-		if "$MKOSI_INITRD" --kernel-version "$kver" -O "$MKOSI_INITRD_STAGING_DIR" -o "initrd-$kver" \
-			&& chmod 600 "$MKOSI_INITRD_STAGING_DIR/initrd-$kver" \
-			&& cp --reflink=auto "$MKOSI_INITRD_STAGING_DIR/initrd-$kver" "/boot/initrd-$kver"; then
-			rm -f "$MKOSI_INITRD_STAGING_DIR/initrd-$kver"*
-		else
-			return $?
-		fi
+		"$MKOSI_INITRD" --kernel-version "$kver" -O "/boot" -o "initrd-$kver" || return $?
 	done
 }
-
-initrd_cleanup() {
-	rm -rf "$MKOSI_INITRD_STAGING_DIR"
-}
-

--- a/regenerate-initrd-posttrans
+++ b/regenerate-initrd-posttrans
@@ -118,9 +118,6 @@ for f in "$dir"/*; do
 	fi
 done
 
-# Clean-up before exit
-trap 'initrd_cleanup' EXIT
-
 # For XEN/grub2 configurations, make sure the updated initrds are copied
 # to the EFI system partition. See /etc/grub.d/20_linux_xen.
 # The test for xen*.gz is simplistic but should be correct here.

--- a/weak-modules2
+++ b/weak-modules2
@@ -534,9 +534,8 @@ needs_initrd() {
 	    echo "Please run \"$DRACUT -f /boot/initrd-$krel $krel\" as soon as your system is complete." >&2
 	    ;;
 	"mkosi-initrd")
-	    # FIXME: mkosi-initrd fails to cp files directly to /boot
-	    echo "Please run \"$MKOSI_INITRD --kernel-version $krel -o initrd-$krel && \
-chmod 600 initrd-$krel && cp initrd-$krel /boot\" as soon as your system is complete." >&2
+	    echo "Please run \"$MKOSI_INITRD --kernel-version $krel -O /boot -o initrd-$krel\" \
+as soon as your system is complete." >&2
 	    ;;
 	esac
 	return 1
@@ -607,11 +606,7 @@ run_depmod_build_initrd() {
 			    doit "$DRACUT" -f "$initrd" $krel
 			    ;;
 			"mkosi-initrd")
-			    # FIXME: mkosi-initrd fails to cp files directly to /boot
-			    doit "$MKOSI_INITRD" --kernel-version "$krel" -O "$tmpdir" -o "initrd-$krel" && \
-			    doit chmod 600 "$tmpdir/initrd-$krel" && \
-			    doit cp --reflink=auto "$tmpdir/initrd-$krel" "$initrd" && \
-			    doit rm -f "$tmpdir/initrd-$krel"*
+			    doit "$MKOSI_INITRD" --kernel-version "$krel" -O "/boot" -o "initrd-$krel"
 			    ;;
 		    esac
 		fi


### PR DESCRIPTION
Before v25, mkosi-initrd failed to build initrds directly to /boot, and also to set proper permissions. Even the requested output file was a symlink to the compressed file with another extension. With v25 in Factory since snapshot 20250124, some workarounds can be removed.

Ref:
- https://github.com/systemd/mkosi/commit/3454f7bd4ef0336ec80a117d593baaef0fe53398
- https://github.com/systemd/mkosi/commit/3fe62ba52099e38920dc07cf3d3a90d048dfa954
- https://github.com/systemd/mkosi/commit/6b0dfe58f3f04264f1df5cb90b7091195913562f