### PR TITLE
mkosi-initrd: perform some basic checks on regenerate all

### DIFF
--- a/mkosi-initrd-posttrans
+++ b/mkosi-initrd-posttrans
@@ -23,6 +23,7 @@ initrd_regenerate_all() {
 	# FIXME: mkosi-initrd does not provide anything like --regenerate-all yet
 	for d in /lib/modules/*; do
 		[ -d "$d" ] || continue
+		[ -f "$d/modules.dep" ] || [ -f "$d/modules.dep.bin" ] || continue
 		kver=${d##*/}
 		"$MKOSI_INITRD" --kernel-version "$kver" -O "/boot" -o "initrd-$kver" || return $?
 	done


### PR DESCRIPTION
dracut performs some basic checks before building the initrds with `--regenerate-all` for all kernel directories, avoiding the build without returning error if the checks are not met. So we have to do the same for mkosi-initrd. This fixes system updates when KMPs are installed, as they install their kernel modules in the updates folder of a specific kernel directory, even if that directory has no other content.