### PR TITLE
spec file: add missing util-linux requirement

### DIFF
--- a/suse-module-tools.spec
+++ b/suse-module-tools.spec
@@ -53,6 +53,7 @@ Requires:       coreutils
 Requires:       findutils
 Requires:       systemd-rpm-macros
 Requires:       rpm
+Requires:       util-linux
 Requires(post): /usr/bin/grep
 Requires(post): /usr/bin/sed
 Requires(post): coreutils


### PR DESCRIPTION
Issue reported by the systemd upstream CI:

```
2025-04-24T06:12:16.5211892Z (321/409) Installing: kernel-default-6.14.2-1.1.x86_64 [....................................................................................................
2025-04-24T06:12:16.5212812Z /usr/lib/module-init-tools/kernel-scriptlets/rpm-post: line 176: mountpoint: command not found
2025-04-24T06:12:16.5215369Z /usr/lib/module-init-tools/kernel-scriptlets/rpm-post: line 176: mountpoint: command not found
2025-04-24T06:12:16.5282697Z /usr/lib/module-init-tools/weak-modules2: line 887: getopt: command not found
2025-04-24T06:12:16.5287258Z Usage:
2025-04-24T06:12:16.5298235Z     weak-modules2 --add-kmp kmp-name-version-release
2025-04-24T06:12:16.5302921Z     weak-modules2 --remove-kmp kmp-name < module-list
2025-04-24T06:12:16.5303688Z     weak-modules2 --add-kernel kernel-release
2025-04-24T06:12:16.5304202Z     weak-modules2 --remove-kernel kernel-release
2025-04-24T06:12:16.5304812Z     weak-modules2 --add-kernel-modules kernel-release < module-list
2025-04-24T06:12:16.5305522Z     weak-modules2 --remove-kernel-modules kernel-release < module-list
2025-04-24T06:12:16.5306092Z     weak-modules2 --verbose ...
2025-04-24T06:12:16.5306481Z     weak-modules2 --dry-run ...
2025-04-24T06:12:16.5306935Z You may need to setup and install the boot loader using the
2025-04-24T06:12:16.5307611Z available bootloader for your platform (e.g. grub, lilo, zipl, ...).
2025-04-24T06:12:16.5308353Z ERROR: cannot create symlinks /boot/vmlinuz and /boot/initrd
2025-04-24T06:12:16.5351369Z warning: %post(kernel-default-6.14.2-1.1.x86_64) scriptlet failed, exit status 1
2025-04-24T06:12:16.5581856Z done]
```