### PR TITLE
Sles12 sp7 alternative kmp path

### DIFF
--- a/driver-check.sh
+++ b/driver-check.sh
@@ -176,7 +176,7 @@ check_kmp()
 	if ! rpm -q -R "$kmp" | grep -Eq "$req_re"; then
 		error "$kmp does not have proper dependencies"
 	fi
-	exec 3< <(sed -rn 's:^(/lib/modules)?/([^/]*)/(.*\.ko(\.[gx]z|\.zst)?)$:\1 \2 \3:p' \
+	exec 3< <(sed -rn 's:^(/lib/modules(/kmp)?)?/([^/]*)/(.*\.ko(\.[gx]z|\.zst)?)$:\1 \3 \4:p' \
 		"$tmp/rpms/$kmp")
 	while read prefix krel path <&3; do
 		found_module=true

--- a/weak-modules2
+++ b/weak-modules2
@@ -3,10 +3,10 @@
 ##############################################################################
 # How it works:
 # * Kernels install modules below /lib/modules/$krel/kernel/.
-# * KMPs install modules below /lib/modules/$krel/updates/ or .../extra/.
+# * KMPs install modules below /lib/modules/[kmp/]$krel/updates/ or .../extra/.
 # * Symbolic links to modules of compatible KMPs are created under
 #   /lib/modules/$krel/weak-updates/{updates,extra}/... (the original path
-#   below /lib/modules/$other_krel is used).
+#   below /lib/modules/[kmod/]$other_krel is used).
 # * Depmod searches the directories in this order: updates/, extra/,
 #   weak-updates/, kernel/ (see /etd/depmod.conf or
 #   /etc/depmod.d/00-system.conf for details).
@@ -121,9 +121,11 @@ strip_mod_extensions() {
 
 # Name of the symlink that makes a module available to a given kernel
 symlink_to_module() {
-    local module=$1 krel=$2
+    local module=$1 krel=$2 val
 
-    echo /lib/modules/$krel/weak-updates/${module#/lib/modules/*/}
+    val=${module#/lib/modules/}
+    val=${val#kmp/}
+    echo /lib/modules/$krel/weak-updates/${val#*/}
 }
 
 # Is a kmp already present in or linked to from this kernel?
@@ -280,7 +282,7 @@ check_kmp() {
     local kmp=$1
 
     # Make sure all modules are for the same kernel
-    set -- $(sed -re 's:^/lib/modules/([^/]+)/.*:\1:' \
+    set -- $(sed -re 's:^/lib/modules(/kmp)?/([^/]+)/.*:\2:' \
 		 $tmpdir/modules-$kmp \
 	     | sort -u)
     if [ $# -ne 1 ]; then
@@ -292,7 +294,7 @@ check_kmp() {
     dlog "check_kmp: $kmp contains modules for $1"
 
     # Make sure none of the modules are in kernel/ or weak-updates/
-    if grep -qE -e '^/lib/modules/[^/]+/(kernel|weak-updates)/' \
+    if grep -qE -e '^/lib/modules(/kmp)?/[^/]+/(kernel|weak-updates)/' \
 	    $tmpdir/modules-$kmp; then
 	echo "Error: package $kmp must not install modules into " \
 	     "kernel/ or weak-updates/" >&2
@@ -317,7 +319,7 @@ find_kmps() {
 	    continue
 	fi
 	rpm -ql --nodigest --nosignature "$kmp" \
-	    | sed -nr 's:^(/usr)?(/lib/modules/[^/]+/.+\.ko)(\.[gx]z|\.zst)?$:\2\3:p' \
+	    | sed -nr 's:^(/usr)?(/lib/modules(/kmp)?/[^/]+/.+\.ko)(\.[gx]z|\.zst)?$:\2\4:p' \
 	    > $tmpdir/modules-$kmp
 	if [ $? != 0 ]; then
 	    echo "WARNING: $kmp does not contain any kernel modules" >&2


### PR DESCRIPTION
This is experimental code that adds /lib/modules/kmp(/<kver>) als alternativen module install path. The advantage of this path is that the KMP is not directly installed into the kernel it was built with. Instead weak-updates2 should take care of making this available for this kernel as well.
This ensures there are not multiple versions of the same module available for a single kernel.