### PR TITLE
weak-modules2: skip livepatch dir when checking for unresolved symbols

### DIFF
--- a/weak-modules2
+++ b/weak-modules2
@@ -233,6 +233,7 @@ create_temporary_modules_dir() {
 
     eval "$(find $modules_dir -path "$modules_dir/modules.*" -prune \
 		-o -path "$modules_dir/kernel" -prune \
+		-o -path "$modules_dir/livepatch" -prune \
 		-o -type d -printf "mkdir -p $opt_v $basedir%p\n" \
 		-o -printf "ln -s $opt_v %p $basedir%p\n"
            )"


### PR DESCRIPTION
Some livepatch modules are built without symbol versions. They are always built for one specific kernel.
Avoid that they cause false positives in the unresolved symbols check.

See https://bugzilla.suse.com/show_bug.cgi?id=1250655